### PR TITLE
⚡ Bolt: Parallelize historical results fetching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -33,3 +33,7 @@
 ## 2026-05-22 - Parallelizing Deduplication Regression
 **Learning:** When moving from immediate sequential processing to batch processing (e.g., collecting tasks for a thread pool), checks against the results cache inside the loop become ineffective because the cache isn't updated until tasks complete.
 **Action:** Use a local `seen` set to track items processed *within* the current batch generation loop to restore deduplication logic.
+
+## 2026-05-23 - Granular Parallelization
+**Learning:** Even when a top-level loop (e.g., iterating years) has dependencies that prevent full parallelization (e.g., early exit based on data), parallelizing independent IO operations *within* the loop body (e.g., race/qual/sprint fetch) still yields significant gains (3x speedup).
+**Action:** Look for clusters of independent IO calls within sequential loops and wrap them in a local `ThreadPoolExecutor`.


### PR DESCRIPTION
⚡ Bolt: Parallelize historical results fetching

💡 What:
Modified `f1pred/features.py` to fetch race, qualifying, and sprint results concurrently for each season using `ThreadPoolExecutor`.

🎯 Why:
Sequential API calls were a bottleneck when building historical data (especially for cold cache). Each year required 3 separate round-trips.

📊 Impact:
Reduces the time to fetch data for a single season by approx 66% (3 sequential calls -> 1 parallel block).
In a simulated benchmark with 0.1s latency per call, fetching 3 years of data dropped from 0.91s to 0.33s.

🔬 Measurement:
Ran `repro_perf.py` (simulated latency) showing ~3x speedup.
Ran full test suite `pytest tests/` to ensure no regression.


---
*PR created automatically by Jules for task [8070326752436731877](https://jules.google.com/task/8070326752436731877) started by @2fst4u*