### PR TITLE
🎨 Palette: CLI Local Time & Legend Update

### DIFF
--- a/f1pred/predict.py
+++ b/f1pred/predict.py
@@ -823,6 +823,21 @@ def print_session_console(
         # Format nice date: "Sat 14:00 UTC"
         date_str = session_date.strftime("%a %H:%M UTC")
 
+        # Add Local Time (UX Improvement)
+        try:
+            local_dt = session_date.astimezone()
+            # Check if local timezone is effectively different from UTC display
+            if local_dt.utcoffset() != timedelta(0):
+                tz_name = local_dt.strftime("%Z").strip()
+                if not tz_name:
+                    # Fallback to offset if name is empty
+                    tz_name = local_dt.strftime("%z").strip()
+
+                local_str = f"{local_dt.strftime('%H:%M')} {tz_name}"
+                date_str += f" ({local_str})"
+        except Exception:
+            pass
+
         if total_seconds > 0:
             days = total_seconds // 86400
             hours = (total_seconds % 86400) // 3600
@@ -1042,4 +1057,4 @@ def print_session_console(
         print(row_str)
 
     # Print legend explaining abbreviations
-    print(f"\n{Style.DIM}Legend: Avg=Predicted Mean Pos, Top3=Podium Prob, {win_label}=Win/Pole Prob, Δ=Grid Delta{Style.RESET_ALL}")
+    print(f"\n{Style.DIM}Legend: Avg=Predicted Mean Pos, Top3=Podium Prob, {win_label}=Win/Pole Prob, DNF=Retirement Prob, Δ=Grid Delta{Style.RESET_ALL}")


### PR DESCRIPTION
💡 What: Added Local Time display to the CLI session header and updated the Legend to include 'DNF=Retirement Prob'.
🎯 Why: Users often struggle with timezone conversions for global events. The DNF column was undefined in the legend.
📸 Before: `🕒 Tue 20:42 UTC` | Legend missing DNF
📸 After: `🕒 Tue 20:42 UTC (15:42 EST)` | Legend includes `DNF=Retirement Prob`
♿ Accessibility: Reduces cognitive load for timezone conversion.

---
*PR created automatically by Jules for task [10832739030595997778](https://jules.google.com/task/10832739030595997778) started by @2fst4u*