### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Client-Side DoS via Malformed Content-Length

### DIFF
--- a/f1pred/util.py
+++ b/f1pred/util.py
@@ -196,8 +196,13 @@ def http_get_json(session: requests.Session, url: str, params: Optional[Dict[str
 
         # Check Content-Length header if present
         cl = resp.headers.get("Content-Length")
-        if cl and int(cl) > MAX_SIZE:
-             raise ValueError(f"Response too large ({cl} bytes) from {url}")
+        if cl:
+            try:
+                if int(cl) > MAX_SIZE:
+                    raise ValueError(f"Response too large ({cl} bytes) from {url}")
+            except ValueError:
+                # Malformed Content-Length; proceed (we enforce limit during read anyway)
+                pass
 
         # Read content with limit
         content = bytearray()


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Client-Side DoS via Malformed Content-Length

🚨 Severity: MEDIUM
💡 Vulnerability: The application's HTTP client utility `http_get_json` would crash with a `ValueError` if a server returned a non-integer `Content-Length` header (e.g. "garbage" or multiple values), leading to a Denial of Service.
🎯 Impact: A malicious or buggy server could crash the prediction tool, interrupting automated workflows or live mode.
🔧 Fix: Wrapped the `int(Content-Length)` conversion in a `try...except ValueError` block. If parsing fails, the check is skipped, but the safe streaming read loop continues to enforce the maximum response size limit, maintaining security against memory exhaustion.
✅ Verification: Created a reproduction script `reproduce_issue.py` which confirmed the crash, applied the fix, and verified the script no longer crashes. Existing test suite passed.


---
*PR created automatically by Jules for task [4463456367014046789](https://jules.google.com/task/4463456367014046789) started by @2fst4u*