### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS Protection Bypass in Content-Length Check

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -30,3 +30,8 @@
 **Vulnerability:** The `circuit_name` retrieved from the external Jolpica API was printed directly to the console in the prediction header without sanitization. A malicious or compromised API response containing ANSI escape codes could inject color codes or potentially execute terminal commands (Terminal Spoofing).
 **Learning:** Even when most fields (drivers, teams) are sanitized, "metadata" fields like circuit names or event titles must also be treated as untrusted input when displaying to a terminal.
 **Prevention:** Applied `sanitize_for_console` to the `circuit_name` variable in `print_session_console`. All external string data destined for stdout must pass through this sanitizer.
+
+## 2025-02-24 - DoS Protection Bypass in Content-Length Check
+**Vulnerability:** The `Content-Length` check in `http_get_json` intended to prevent downloading large files was ineffective. The `ValueError` raised when the size limit was exceeded was improperly caught by a `try-except` block designed to handle malformed headers, allowing large downloads to proceed.
+**Learning:** Exception handling for validation (like parsing integers) must be narrowly scoped. Catching exceptions too broadly (or catching the exception you just raised) can silently disable security controls.
+**Prevention:** Refactored the `try-except` block to only cover the integer conversion. The size limit check is now performed outside the `try` block to ensure the rejection exception propagates correctly.

--- a/f1pred/util.py
+++ b/f1pred/util.py
@@ -198,11 +198,13 @@ def http_get_json(session: requests.Session, url: str, params: Optional[Dict[str
         cl = resp.headers.get("Content-Length")
         if cl:
             try:
-                if int(cl) > MAX_SIZE:
-                    raise ValueError(f"Response too large ({cl} bytes) from {url}")
+                cl_int = int(cl)
             except ValueError:
                 # Malformed Content-Length; proceed (we enforce limit during read anyway)
-                pass
+                cl_int = 0
+
+            if cl_int > MAX_SIZE:
+                raise ValueError(f"Response too large ({cl} bytes) from {url}")
 
         # Read content with limit
         content = bytearray()

--- a/tests/test_security_dos.py
+++ b/tests/test_security_dos.py
@@ -1,0 +1,30 @@
+
+import unittest
+from unittest.mock import MagicMock
+from f1pred.util import http_get_json
+
+class TestSecurityDoS(unittest.TestCase):
+    def test_content_length_check_enforced(self):
+        """
+        Security Test: Ensure that http_get_json strictly respects the Content-Length header.
+        Prevents DoS via resource consumption by failing FAST if the header indicates
+        a response larger than the 10MB limit.
+        """
+        session = MagicMock()
+        response = MagicMock()
+        session.get.return_value.__enter__.return_value = response
+
+        # Scenario: Content-Length is valid integer but too large (20MB)
+        # MAX_SIZE is 10MB in util.py
+        response.headers = {"Content-Length": str(20 * 1024 * 1024)}
+        response.iter_content.return_value = [b"chunk"]
+        response.encoding = "utf-8"
+
+        # Must raise ValueError("Response too large...")
+        with self.assertRaises(ValueError) as cm:
+            http_get_json(session, "http://example.com")
+
+        self.assertIn("Response too large", str(cm.exception))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `http_get_json` function intended to prevent large downloads failed to enforce the size limit because the `ValueError` raised for the limit violation was caught by a generic `try-except` block designed for integer parsing.
🎯 Impact: Attackers could bypass DoS protection and cause the application to consume excessive bandwidth and time downloading large files, even though a secondary chunk-based limit eventually stops it.
🔧 Fix: Refactored the `try-except` block to narrowly scope the integer conversion. The size limit check is now performed outside the `try` block, ensuring the rejection exception propagates immediately.
✅ Verification: Added regression test `tests/test_security_dos.py` which verifies that a `ValueError` is raised when the `Content-Length` header exceeds the limit.

---
*PR created automatically by Jules for task [15389279129546695547](https://jules.google.com/task/15389279129546695547) started by @2fst4u*