### PR TITLE
🛡️ Sentinel: Enforce input length limits to prevent DoS

### DIFF
--- a/f1pred/data/jolpica.py
+++ b/f1pred/data/jolpica.py
@@ -129,6 +129,11 @@ class JolpicaClient:
         r = str(rnd).strip()
         if r in ("last", "next"):
             return r
+
+        # Enforce length limit (F1 rounds are rarely > 25, 5 digits is extremely generous)
+        if len(r) > 5:
+            raise ValueError(f"Invalid round (too long): {repr(r[:10])}...")
+
         if not r.isdigit():
             # Use repr() to prevent log injection from malicious input
             raise ValueError(f"Invalid round: {repr(rnd)}")

--- a/f1pred/data/open_meteo.py
+++ b/f1pred/data/open_meteo.py
@@ -57,6 +57,12 @@ class OpenMeteoClient:
         """Ensure timezone string contains only safe characters."""
         # Basic timezone validation (allow UTC, auto, or Region/City)
         tz = str(tz or "UTC").strip()
+
+        # Enforce length limit (standard IANA timezones are typically < 40 chars)
+        if len(tz) > 64:
+             logger.warning(f"OpenMeteoClient: timezone too long, falling back to UTC")
+             return "UTC"
+
         if not all(c.isalnum() or c in "/-_+" for c in tz):
             # Using logger.warning here might be too noisy if called frequently with bad data,
             # but for now we want to know if validation fails.

--- a/f1pred/util.py
+++ b/f1pred/util.py
@@ -37,10 +37,19 @@ def sanitize_for_console(text: str) -> str:
     """
     Remove ANSI escape codes and control characters from text to prevent terminal injection
     and log forging/spoofing.
+
+    Also truncates excessively long inputs to prevent Log Flooding and Terminal DoS.
     """
+    s_text = str(text)
+
+    # Truncate to prevent Log Flooding / Resource Exhaustion
+    MAX_LOG_LENGTH = 1024
+    if len(s_text) > MAX_LOG_LENGTH:
+        s_text = s_text[:MAX_LOG_LENGTH] + "...[truncated]"
+
     # 7-bit C1 ANSI sequences
     ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
-    text = ansi_escape.sub('', str(text))
+    text = ansi_escape.sub('', s_text)
 
     # Replace newlines/tabs with space to preserve readability but prevent structure break
     text = re.sub(r'[\r\n\t\v\f]', ' ', text)

--- a/tests/test_security_input_limits.py
+++ b/tests/test_security_input_limits.py
@@ -1,0 +1,50 @@
+
+import unittest
+import logging
+from f1pred.util import sanitize_for_console
+from f1pred.data.jolpica import JolpicaClient
+from f1pred.data.open_meteo import OpenMeteoClient
+
+class TestSecurityInputLimits(unittest.TestCase):
+    def test_sanitize_truncation(self):
+        """
+        Security Test: Ensure sanitize_for_console truncates extremely long inputs
+        to prevent Log Flooding and Terminal DoS.
+        """
+        # Create a massive string (e.g. 10KB)
+        long_input = "A" * 10000
+        sanitized = sanitize_for_console(long_input)
+
+        # Expect truncation to reasonable limit (e.g. 1024)
+        # We test for <= 1024 + minimal overhead (suffix)
+        # 1024 + len("...[truncated]") = 1024 + 14 = 1038
+        self.assertLessEqual(len(sanitized), 1050)
+        self.assertTrue(sanitized.startswith("AAAA"))
+        self.assertTrue(sanitized.endswith("[truncated]"))
+
+    def test_jolpica_round_limit(self):
+        """
+        Security Test: Ensure JolpicaClient rejects excessively long round strings
+        to prevent upstream DoS / URL length issues.
+        """
+        jc = JolpicaClient("http://mock")
+        long_round = "1" * 1000  # 1000 digits
+
+        # Should raise ValueError immediately due to length, before isdigit checks
+        # or as part of validation
+        with self.assertRaises(ValueError):
+            jc._validate_round(long_round)
+
+    def test_openmeteo_timezone_limit(self):
+        """
+        Security Test: Ensure OpenMeteoClient limits timezone string length.
+        """
+        om = OpenMeteoClient("http://mock", "http://mock", "http://mock", "http://mock", "http://mock")
+        long_tz = "Europe/London" + ("/" * 1000)
+
+        # Should return "UTC" fallback or raise, but definitely not return the massive string
+        result = om._validate_timezone(long_tz)
+        self.assertEqual(result, "UTC")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_security_log_injection.py
+++ b/tests/test_security_log_injection.py
@@ -36,4 +36,7 @@ def test_validate_round_log_injection_prevention():
     msg = str(excinfo.value)
     assert "\n" not in msg
     assert "\\n" in msg
-    assert "1\\nINFO: Fake Log" in msg
+    # The input triggers the length limit check first (max 5 chars)
+    # So we expect the "too long" error message, which also uses repr()
+    assert "Invalid round (too long)" in msg
+    assert "1\\nINFO" in msg


### PR DESCRIPTION
🛡️ Sentinel: [Security Enhancement] Enforce input length limits to prevent DoS and Log Flooding.

**Summary:**
This PR introduces input validation and sanitization improvements to protect the application from Resource Exhaustion (DoS) and Log Flooding attacks.

**Changes:**
1.  **Input Validation:** `JolpicaClient` now rejects round numbers longer than 5 characters. `OpenMeteoClient` falls back to UTC if the timezone string exceeds 64 characters.
2.  **Output Sanitization:** `sanitize_for_console` (used by the logger) now truncates strings longer than 1024 characters, preventing massive inputs from flooding the logs or terminal.
3.  **Testing:** Added `tests/test_security_input_limits.py` to verify these protections. Updated `tests/test_security_log_injection.py` to align with the new truncation behavior.

**Impact:**
- Mitigates risk of DoS via massive input strings in API clients.
- Prevents attackers from flooding logs by injecting extremely long strings into exception messages.
- Ensures the application remains responsive and secure against malformed inputs.

---
*PR created automatically by Jules for task [10724962608007685504](https://jules.google.com/task/10724962608007685504) started by @2fst4u*