### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Insecure Deserialization in Cache

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,8 @@
 **Vulnerability:** The `Content-Length` check in `http_get_json` intended to prevent downloading large files was ineffective. The `ValueError` raised when the size limit was exceeded was improperly caught by a `try-except` block designed to handle malformed headers, allowing large downloads to proceed.
 **Learning:** Exception handling for validation (like parsing integers) must be narrowly scoped. Catching exceptions too broadly (or catching the exception you just raised) can silently disable security controls.
 **Prevention:** Refactored the `try-except` block to only cover the integer conversion. The size limit check is now performed outside the `try` block to ensure the rejection exception propagates correctly.
+
+## 2026-05-25 - Insecure Deserialization in Cache
+**Vulnerability:** The default `sqlite` backend in `requests-cache` used `pickle` for serialization. If an attacker could modify the cache file (e.g., in a shared environment before permission hardening), they could achieve arbitrary code execution upon deserialization.
+**Learning:** Convenience libraries often default to Python-specific serialization (pickle) which is unsafe for untrusted data. Even with file permissions, this is a dangerous default.
+**Prevention:** Explicitly configured `serializer="json"` in `requests-cache` to enforce safe serialization. Also hardened directory permissions with `umask` to prevent race conditions during cache creation.


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Insecure Deserialization in Cache

🚨 Severity: CRITICAL
💡 Vulnerability: The default `sqlite` backend in `requests-cache` uses `pickle` for serialization. This poses a remote code execution (RCE) risk if the cache file is tampered with. Additionally, `ensure_dirs` had a race condition where directories were created with default permissions before being `chmod`ed.
🎯 Impact: RCE via cache poisoning; Potential information leak via race condition on directory permissions.
🔧 Fix:
  - Enabled `serializer='json'` in `requests-cache` configuration.
  - Implemented `os.umask` context manager in `ensure_dirs` for atomic permission enforcement.
✅ Verification:
  - Verified JSON serialization with reproduction script.
  - Ran full test suite (`pytest`) with no regressions.


---
*PR created automatically by Jules for task [4334651057575284056](https://jules.google.com/task/4334651057575284056) started by @2fst4u*