### PR TITLE
🎨 Palette: CLI Session Smart Aliases

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-31 - CLI Session Aliasing
+**Learning:** Users often use shorthand for F1 sessions (e.g., "q" for Qualifying, "gp" for Race).
+**Action:** Implement a normalization layer in `main.py` that maps aliases to canonical names and uses `difflib` for fuzzy suggestions on typos. This pattern can be applied to other CLI args like `--round`.


### PR DESCRIPTION
Improved the CLI user experience by making the `--sessions` argument more forgiving. Users can now use common aliases (like `q`, `r`, `s`) and receive helpful suggestions if they make a typo. This aligns with the "Palette" philosophy of intuitive and delightful micro-interactions.

---
*PR created automatically by Jules for task [15503363717152763958](https://jules.google.com/task/15503363717152763958) started by @2fst4u*