### PR TITLE
🎨 UX: Color-code F1 team names in CLI output

### DIFF
--- a/f1pred/predict.py
+++ b/f1pred/predict.py
@@ -808,6 +808,38 @@ def _get_prob_color(value: float, is_dnf: bool = False) -> str:
     return Fore.YELLOW
 
 
+def _get_team_color(team_name: str) -> str:
+    """Return colorama color based on team name."""
+    if not team_name:
+        return Style.DIM
+
+    t = team_name.lower()
+
+    # Ferrari (Red)
+    if "ferrari" in t: return Fore.RED
+
+    # Red Bull / RB / AlphaTauri (Blue)
+    if "red bull" in t: return Fore.BLUE
+    if "rb" in t or "alpha" in t: return Fore.BLUE
+    if "alpine" in t: return Fore.MAGENTA  # Pink/Blue mix
+    if "williams" in t: return Fore.BLUE + Style.BRIGHT
+
+    # Mercedes (Cyan/Silver)
+    if "mercedes" in t: return Fore.CYAN
+
+    # McLaren (Yellow/Orange)
+    if "mclaren" in t: return Fore.YELLOW
+
+    # Aston Martin (Green)
+    if "aston martin" in t: return Fore.GREEN
+    if "kick" in t or "sauber" in t: return Fore.GREEN + Style.BRIGHT
+
+    # Haas (White)
+    if "haas" in t: return Fore.WHITE
+
+    return Style.DIM
+
+
 def _render_actual_pos(predicted: int, actual: int, width: int = 6) -> str:
     """Render actual position with accuracy-based color coding and alignment."""
     diff = abs(predicted - actual)
@@ -1113,11 +1145,12 @@ def print_session_console(
             classified_str = f"{Style.DIM}{'--':>6}{Style.RESET_ALL}"
         
         # Print row
+        team_color = _get_team_color(r.get("constructorName") or "")
         row_str = (
             f"{Fore.YELLOW}{pos:>3}.{Style.RESET_ALL}  "
             f"{Style.BRIGHT}{code:<4}{Style.RESET_ALL}  "
             f"{Fore.CYAN}{name:<{max_name}}{Style.RESET_ALL}   "
-            f"{Style.DIM}[{team:<{max_team}}]{Style.RESET_ALL}   "
+            f"{team_color}[{team:<{max_team}}]{Style.RESET_ALL}   "
         )
 
         if has_grid:

--- a/tests/test_ux_colors.py
+++ b/tests/test_ux_colors.py
@@ -1,0 +1,32 @@
+import pytest
+from colorama import Fore, Style
+from f1pred.predict import _get_team_color
+
+@pytest.mark.parametrize("team_name, expected_color", [
+    ("Ferrari", Fore.RED),
+    ("Scuderia Ferrari", Fore.RED),
+    ("Red Bull Racing", Fore.BLUE),
+    ("Oracle Red Bull Racing", Fore.BLUE),
+    ("Mercedes", Fore.CYAN),
+    ("Mercedes-AMG PETRONAS F1 Team", Fore.CYAN),
+    ("McLaren", Fore.YELLOW),
+    ("McLaren F1 Team", Fore.YELLOW),
+    ("Aston Martin", Fore.GREEN),
+    ("Aston Martin Aramco F1 Team", Fore.GREEN),
+    ("Alpine", Fore.MAGENTA),
+    ("BWT Alpine F1 Team", Fore.MAGENTA),
+    ("Williams", Fore.BLUE + Style.BRIGHT),
+    ("Williams Racing", Fore.BLUE + Style.BRIGHT),
+    ("Haas F1 Team", Fore.WHITE),
+    ("MoneyGram Haas F1 Team", Fore.WHITE),
+    ("Kick Sauber", Fore.GREEN + Style.BRIGHT),
+    ("Stake F1 Team Kick Sauber", Fore.GREEN + Style.BRIGHT),
+    ("RB", Fore.BLUE),
+    ("Visa Cash App RB F1 Team", Fore.BLUE),
+    ("AlphaTauri", Fore.BLUE), # Legacy support
+    ("Unknown Team", Style.DIM),
+    ("", Style.DIM),
+    (None, Style.DIM),
+])
+def test_get_team_color(team_name, expected_color):
+    assert _get_team_color(team_name) == expected_color


### PR DESCRIPTION
Implemented a micro-UX improvement by color-coding F1 team names in the CLI output. This makes the prediction table much more readable and visually appealing for F1 fans who associate teams with their livery colors.

Changes:
- Added `_get_team_color` function in `f1pred/predict.py`.
- Updated `print_session_console` to apply these colors to the `[Team]` column.
- Added comprehensive unit tests in `tests/test_ux_colors.py` covering current grid teams.

The implementation gracefully handles unknown teams by falling back to `Style.DIM` and works with the existing `colorama` setup.

---
*PR created automatically by Jules for task [8206025465168043999](https://jules.google.com/task/8206025465168043999) started by @2fst4u*