### PR TITLE
🎨 Palette: Add podium color highlighting to results table

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-09 - Environmental Context Scannability
 **Learning:** Adding visual icons (☀️, ☁️, 💧) for environmental conditions in the CLI allows users to scan race context much faster than text alone.
 **Action:** Use specific, recognizable emoji for key environmental variables alongside numerical data to improve "at a glance" readability.
+
+## 2026-02-15 - Visual Hierarchy in Rankings
+**Learning:** For ranked lists, color-coding the top positions (Gold/Silver/Bronze) provides immediate visual structure and celebrates success without needing cluttered icons or emojis.
+**Action:** Use distinct colors for top 3 items in any ranked list to guide the eye.

--- a/f1pred/predict.py
+++ b/f1pred/predict.py
@@ -840,6 +840,17 @@ def _get_team_color(team_name: str) -> str:
     return Style.DIM
 
 
+def _get_pos_color(pos: int) -> str:
+    """Return color code based on predicted position (Gold/Silver/Bronze for Top 3)."""
+    if pos == 1:
+        return Fore.YELLOW + Style.BRIGHT  # Gold
+    if pos == 2:
+        return Fore.WHITE + Style.BRIGHT   # Silver
+    if pos == 3:
+        return Fore.MAGENTA + Style.BRIGHT # Bronze
+    return Fore.RESET + Style.DIM          # Others
+
+
 def _render_actual_pos(predicted: int, actual: int, width: int = 6) -> str:
     """Render actual position with accuracy-based color coding and alignment."""
     diff = abs(predicted - actual)
@@ -1146,8 +1157,9 @@ def print_session_console(
         
         # Print row
         team_color = _get_team_color(r.get("constructorName") or "")
+        pos_color = _get_pos_color(pos)
         row_str = (
-            f"{Fore.YELLOW}{pos:>3}.{Style.RESET_ALL}  "
+            f"{pos_color}{pos:>3}.{Style.RESET_ALL}  "
             f"{Style.BRIGHT}{code:<4}{Style.RESET_ALL}  "
             f"{Fore.CYAN}{name:<{max_name}}{Style.RESET_ALL}   "
             f"{team_color}[{team:<{max_team}}]{Style.RESET_ALL}   "

--- a/tests/test_ux_podium_colors.py
+++ b/tests/test_ux_podium_colors.py
@@ -1,0 +1,18 @@
+
+import pytest
+from colorama import Fore, Style
+from f1pred.predict import _get_pos_color
+
+def test_get_pos_color_gold():
+    assert _get_pos_color(1) == Fore.YELLOW + Style.BRIGHT
+
+def test_get_pos_color_silver():
+    assert _get_pos_color(2) == Fore.WHITE + Style.BRIGHT
+
+def test_get_pos_color_bronze():
+    assert _get_pos_color(3) == Fore.MAGENTA + Style.BRIGHT
+
+def test_get_pos_color_others():
+    assert _get_pos_color(4) == Fore.RESET + Style.DIM
+    assert _get_pos_color(10) == Fore.RESET + Style.DIM
+    assert _get_pos_color(20) == Fore.RESET + Style.DIM


### PR DESCRIPTION
Implemented color-coded highlighting for the top 3 positions (Gold, Silver, Bronze) in the CLI prediction table to improve scannability and visual hierarchy, respecting the user's preference against medal emojis.

---
*PR created automatically by Jules for task [2418573774639564965](https://jules.google.com/task/2418573774639564965) started by @2fst4u*