### PR TITLE
🎨 Palette: Improve countdown visual indicator

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -41,3 +41,7 @@
 ## 2026-05-24 - CLI Table Column Clarity
 **Learning:** In prediction tables where rows are ranked by prediction (implicit position), a column labeled "Pos" for the *actual/result* position is ambiguous and confusing. Users may confuse the row index with the result column.
 **Action:** Rename result columns to "Actual" or "Result" to clearly distinguish them from the predicted rank (often denoted by `#` or row order). Update legends to explicitly define the column.
+
+## 2025-05-25 - Semantic Icons in CLI Spinners
+**Learning:** Using a generic asterisk `*` for a countdown spinner is ambiguous and lacks visual polish. Replacing it with a unicode refresh icon `↻` (U+21BB) clearly communicates "refreshing" or "waiting" to the user, aligning the visual language with the action.
+**Action:** Use the `↻` icon for refresh/countdown spinners in CLI tools to improve semantic clarity and visual appeal.

--- a/f1pred/util.py
+++ b/f1pred/util.py
@@ -363,7 +363,7 @@ def print_countdown(seconds: int, message: str = "Refreshing in") -> None:
 
     try:
         for i in range(seconds, 0, -1):
-            sys.stdout.write(f"\r{Style.DIM}* {message} {i}s...{Style.RESET_ALL}\033[K")
+            sys.stdout.write(f"\r{Style.DIM}↻ {message} {i}s...{Style.RESET_ALL}\033[K")
             sys.stdout.flush()
             time.sleep(1)
 


### PR DESCRIPTION
This PR replaces the generic asterisk `*` in the CLI countdown timer with a unicode refresh icon `↻` (U+21BB).

### 💡 What
Replaced `*` with `↻` in `f1pred/util.py`'s `print_countdown` function.

### 🎯 Why
The asterisk was ambiguous. The refresh icon clearly communicates that the system is waiting to refresh or reload, aligning the visual language with the action.

### 📸 Before/After
Before: `* Refreshing in 5s...`
After: `↻ Refreshing in 5s...`

### ♿ Accessibility
The change is purely visual/textual and uses a standard unicode character supported by modern terminals. It does not negatively impact accessibility.


---
*PR created automatically by Jules for task [6603878263588844698](https://jules.google.com/task/6603878263588844698) started by @2fst4u*