### PR TITLE
🧹 Sweep: Remove unused OpenMeteoClient.get_elevation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -24,7 +24,6 @@ data_sources:
     forecast_url: "https://api.open-meteo.com/v1/forecast"
     historical_weather_url: "https://archive-api.open-meteo.com/v1/era5"
     historical_forecast_url: "https://historical-forecast-api.open-meteo.com/v1/forecast"
-    elevation_url: "https://api.open-meteo.com/v1/elevation"
     geocoding_url: "https://geocoding-api.open-meteo.com/v1/search"
     enabled: true
     # Unit choices for Open-Meteo (see docs for acceptable values)

--- a/f1pred/config.py
+++ b/f1pred/config.py
@@ -41,7 +41,6 @@ class OpenMeteo:
     forecast_url: str
     historical_weather_url: str
     historical_forecast_url: str
-    elevation_url: str
     geocoding_url: str
     enabled: bool
     temperature_unit: str
@@ -224,7 +223,6 @@ def load_config(path: str) -> AppConfig:
             "forecast_url",
             "historical_weather_url",
             "historical_forecast_url",
-            "elevation_url",
             "geocoding_url",
         ):
             if not _is_http_url(om.get(ukey, "")):

--- a/f1pred/data/open_meteo.py
+++ b/f1pred/data/open_meteo.py
@@ -21,7 +21,6 @@ class OpenMeteoClient:
                  forecast_url: str,
                  historical_weather_url: str,
                  historical_forecast_url: str,
-                 elevation_url: str,
                  geocoding_url: str,
                  timeout: int = 30,
                  temperature_unit: str = "celsius",
@@ -30,27 +29,12 @@ class OpenMeteoClient:
         self.forecast_url = forecast_url
         self.historical_weather_url = historical_weather_url
         self.historical_forecast_url = historical_forecast_url
-        self.elevation_url = elevation_url
         self.geocoding_url = geocoding_url
         self.timeout = timeout
         self.temperature_unit = temperature_unit
         self.windspeed_unit = windspeed_unit
         self.precipitation_unit = precipitation_unit
         self.session = session_with_retries()
-
-    def get_elevation(self, lat: float, lon: float) -> Optional[float]:
-        if not _valid_lat_lon(lat, lon):
-            logger.info(f"OpenMeteoClient.get_elevation: invalid coordinates lat={repr(lat)}, lon={repr(lon)}")
-            return None
-        js = http_get_json(self.session, self.elevation_url,
-                           params={"latitude": lat, "longitude": lon},
-                           timeout=self.timeout)
-        elev = None
-        try:
-            elev = js.get("elevation", [None])[0] if isinstance(js, dict) else None
-        except Exception:
-            pass
-        return safe_float(elev, None)
 
     @staticmethod
     def _validate_timezone(tz: str) -> str:

--- a/f1pred/predict.py
+++ b/f1pred/predict.py
@@ -364,7 +364,6 @@ def run_predictions_for_event(
         cfg.data_sources.open_meteo.forecast_url,
         cfg.data_sources.open_meteo.historical_weather_url,
         cfg.data_sources.open_meteo.historical_forecast_url,
-        cfg.data_sources.open_meteo.elevation_url,
         cfg.data_sources.open_meteo.geocoding_url,
         timeout=cfg.data_sources.jolpica.timeout_seconds,
         temperature_unit=cfg.data_sources.open_meteo.temperature_unit,

--- a/f1pred/util.py
+++ b/f1pred/util.py
@@ -140,8 +140,6 @@ def init_caches(cfg, disable_cache: bool = False) -> None:
         urls_expire_after[ds.open_meteo.historical_weather_url] = default_expire_seconds
     if getattr(ds.open_meteo, "historical_forecast_url", None):
         urls_expire_after[ds.open_meteo.historical_forecast_url] = default_expire_seconds
-    if getattr(ds.open_meteo, "elevation_url", None):
-        urls_expire_after[ds.open_meteo.elevation_url] = default_expire_seconds
     if getattr(ds.open_meteo, "geocoding_url", None):
         urls_expire_after[ds.open_meteo.geocoding_url] = default_expire_seconds
 

--- a/tests/test_config_security.py
+++ b/tests/test_config_security.py
@@ -30,7 +30,6 @@ class TestConfigSecurity(unittest.TestCase):
                     "forecast_url": "https://api.open-meteo.com",
                     "historical_weather_url": "https://archive-api.open-meteo.com",
                     "historical_forecast_url": "https://historical-forecast-api.open-meteo.com",
-                    "elevation_url": "https://api.open-meteo.com",
                     "geocoding_url": "https://geocoding-api.open-meteo.com",
                     "enabled": True,
                     "temperature_unit": "celsius",

--- a/tests/test_security_input_limits.py
+++ b/tests/test_security_input_limits.py
@@ -39,7 +39,7 @@ class TestSecurityInputLimits(unittest.TestCase):
         """
         Security Test: Ensure OpenMeteoClient limits timezone string length.
         """
-        om = OpenMeteoClient("http://mock", "http://mock", "http://mock", "http://mock", "http://mock")
+        om = OpenMeteoClient("http://mock", "http://mock", "http://mock", "http://mock")
         long_tz = "Europe/London" + ("/" * 1000)
 
         # Should return "UTC" fallback or raise, but definitely not return the massive string

--- a/tests/test_security_vuln.py
+++ b/tests/test_security_vuln.py
@@ -73,7 +73,6 @@ def test_open_meteo_timezone_validation():
         forecast_url="http://mock",
         historical_weather_url="http://mock-hist",
         historical_forecast_url="http://mock-hist-forecast",
-        elevation_url="http://mock-elev",
         geocoding_url="http://mock-geo",
     )
 


### PR DESCRIPTION
Remove unused `OpenMeteoClient.get_elevation` method and associated configuration to reduce bloat.

**Changes:**
- Deleted `get_elevation` method from `f1pred/data/open_meteo.py`.
- Removed `elevation_url` from `OpenMeteoClient` constructor and attributes.
- Removed `elevation_url` from `config.yaml` and `f1pred/config.py`.
- Updated `OpenMeteoClient` instantiation in `f1pred/predict.py`.
- Removed `elevation_url` cache expiration logic in `f1pred/util.py`.
- Updated tests (`tests/test_security_input_limits.py`, `tests/test_security_vuln.py`, `tests/test_config_security.py`) to align with the new constructor signature and configuration.

**Verification:**
- `grep -r "get_elevation" .` returns no matches.
- `grep -r "elevation_url" .` returns no matches related to OpenMeteo configuration.
- `pytest` passed (52 tests passed, after installing missing test dependencies).

---
*PR created automatically by Jules for task [13656730940152728098](https://jules.google.com/task/13656730940152728098) started by @2fst4u*