### PR TITLE
🧪 Spec: Fix broken config test fixture

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,7 +33,6 @@ def full_valid_config():
                 "forecast_url": "https://api.open-meteo.com",
                 "historical_weather_url": "https://archive-api.open-meteo.com",
                 "historical_forecast_url": "https://historical-forecast-api.open-meteo.com",
-                "elevation_url": "https://api.open-meteo.com",
                 "geocoding_url": "https://geocoding-api.open-meteo.com",
                 "enabled": True,
                 "temperature_unit": "celsius",


### PR DESCRIPTION
Removed the 'elevation_url' key from the 'full_valid_config' fixture in 'tests/test_config.py' to align with the current 'OpenMeteo' dataclass definition in 'f1pred/config.py'. This resolves a TypeError during test execution.

---
*PR created automatically by Jules for task [15047815672138351234](https://jules.google.com/task/15047815672138351234) started by @2fst4u*