### PR TITLE
Fix duplicated CI test runs by removing matrix strategy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,17 +7,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
           cache: pip
 
       - name: Install dependencies


### PR DESCRIPTION
Updated `.github/workflows/tests.yml` to remove the matrix strategy and pin the Python version to 3.12. This ensures that unit tests run only once per PR, addressing the user's concern about duplicated test actions. Confirmed that local tests pass on Python 3.12.

---
*PR created automatically by Jules for task [15417162444881434374](https://jules.google.com/task/15417162444881434374) started by @2fst4u*