### PR TITLE
🧪 Spec: Add test for missing driver columns in metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,6 @@ omit = [
 ]
 
 [tool.coverage.report]
-# Locked in gain from metrics.py tests (37% -> 39%)
-fail_under = 39
+# Locked in gain from metrics.py tests (37% -> 39% -> 39.04%)
+fail_under = 39.04
 show_missing = true

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -153,3 +153,12 @@ class TestComputeEventMetrics:
         assert np.isnan(result["spearman"])
         assert np.isnan(result["kendall"])
         assert np.isnan(result["accuracy_top3"])
+
+    def test_no_driver_column(self):
+        df = pd.DataFrame({
+            "predicted_position": [1, 2],
+            "actual_position": [1, 2],
+        })
+        result = compute_event_metrics(df, None, None, "race", 2025, 1)
+        assert np.isnan(result["accuracy_top3"])
+        assert result["spearman"] == pytest.approx(1.0)


### PR DESCRIPTION
💡 **What**: Added a new unit test `test_no_driver_column` to `tests/test_metrics.py` and increased the code coverage threshold in `pyproject.toml`.

🎯 **Why**: The `compute_event_metrics` function has logic to handle DataFrames missing `driver_id` columns (lines 55-60), but this path was previously uncovered. This test ensures that the function gracefully returns `NaN` for accuracy metrics instead of raising a `KeyError` or `AttributeError` when driver identifiers are absent.

📈 **Ratchet**: Increased statement coverage threshold by 0.04% (from 39% to 39.04%) to lock in the gain from this new test.

---
*PR created automatically by Jules for task [9181689029369282897](https://jules.google.com/task/9181689029369282897) started by @2fst4u*