### PR TITLE
📚 Archivist: Fix broken make predict command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install:
 	pip install -r requirements.txt
 
 predict:
-	python main.py --round next --html
+	python main.py --round next
 
 backtest:
 	python main.py --backtest


### PR DESCRIPTION
💡 Problem: The `predict` target in the `Makefile` attempts to run `python main.py --round next --html`. However, the `main.py` entry point does not implement or accept an `--html` argument (verified via grep). This causes `make predict` to fail immediately with an unrecognized arguments error.

🎯 Fix: Removed the obsolete `--html` flag from the `predict` target in the `Makefile` so it correctly maps to the supported command structure `python main.py --round next`.

🧪 Verification: 
- Ran `grep -n "html" main.py` to confirm the flag doesn't exist.
- Checked `README.md` to ensure the Quick Start instructions are aligned.
- Ran test suite to ensure no build regressions.

🔎 Scope: This PR is strictly limited to fixing a broken script configuration to match the current application state. No application code or behavioral changes were introduced.

---
*PR created automatically by Jules for task [6637550888391059735](https://jules.google.com/task/6637550888391059735) started by @2fst4u*