### PR TITLE
🧪 Spec: Add ranking logic tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,5 +35,6 @@ omit = [
 
 [tool.coverage.report]
 # Locked in gain from util.py tests (39.04% -> 46.69%)
-fail_under = 46.69
+# Locked in gain from ranking.py tests (46.69% -> 46.75%)
+fail_under = 46.75
 show_missing = true

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1,6 +1,7 @@
 """Tests for ranking utilities."""
 import pytest
 import numpy as np
+from unittest.mock import patch
 from f1pred.ranking import plackett_luce_scores, rank_from_pace
 
 
@@ -72,3 +73,16 @@ def test_rank_all_same_pace():
     order = rank_from_pace(pace, noise_sd=0)
     # Stable sort should preserve original order
     assert list(order) == [0, 1, 2]
+
+def test_pl_all_non_finite():
+    # Covers line 25: `fill = 0.0` when no finite elements exist
+    scores = np.array([np.nan, np.inf])
+    probs = plackett_luce_scores(scores)
+    assert np.allclose(probs, 0.5)
+
+def test_pl_denom_invalid():
+    # Covers line 44: `return np.full(n, 1.0 / n)` when denom is invalid
+    scores = np.array([1.0, 2.0])
+    with patch('numpy.exp', return_value=np.array([np.nan, np.nan])):
+        probs = plackett_luce_scores(scores)
+        assert np.allclose(probs, [0.5, 0.5])


### PR DESCRIPTION
💡 What: Added unit tests `test_pl_all_non_finite` and `test_pl_denom_invalid` in `tests/test_ranking.py`.
🎯 Why: `plackett_luce_scores` logic contained edge cases that were never reached during normal operation: handling arrays that are entirely `NaN`/`inf` (line 25), and a fallback condition where the softmax denominator became invalid (line 44). Mocks were used to safely reach the invalid denominator fallback.
📈 Ratchet: Increased statement coverage threshold by 0.06% (from 46.69% to 46.75%) to lock in the gain from these new tests.

---
*PR created automatically by Jules for task [9119087656131623342](https://jules.google.com/task/9119087656131623342) started by @2fst4u*