### PR TITLE
🧹 Sweep: Remove unused API endpoint methods

### DIFF
--- a/f1pred/data/jolpica.py
+++ b/f1pred/data/jolpica.py
@@ -283,18 +283,6 @@ class JolpicaClient:
         mr = self._extract_mrdata(js)
         return mr.get("DriverTable", {}).get("Drivers", []) or []
 
-    def get_constructors_for_season(self, season: str) -> List[Dict[str, Any]]:
-        season = self._validate_season(season)
-        js = self._get(f"{season}/constructors.json", params={"limit": 1000})
-        mr = self._extract_mrdata(js)
-        return mr.get("ConstructorTable", {}).get("Constructors", []) or []
-
-    def get_standings(self, season: str) -> Dict[str, Any]:
-        season = self._validate_season(season)
-        js = self._get(f"{season}/driverStandings.json", params={"limit": 1000})
-        mr = self._extract_mrdata(js)
-        return mr.get("StandingsTable", {}) or {}
-
     def get_season_entry_list(self, season: str, max_workers: int = 5) -> List[Dict[str, Any]]:
         """
         Build a season entry list by fetching all drivers and then querying their constructor.


### PR DESCRIPTION
💡 **What:**
Removed `get_constructors_for_season` and `get_standings` from the `JolpicaClient` API wrapper in `f1pred/data/jolpica.py`.

🎯 **Why:**
These two methods were leftover, unused code defined in the API client and were completely orphaned. Keeping them around just contributes to repository bloat without providing value, aligning directly with Sweep's directive that "dead code is a liability, not a backup".

🔬 **Verification:**
Executed the global text search:
`grep -rnw . -e "get_constructors_for_season" -e "get_standings"`
The output only showed the definitions within `f1pred/data/jolpica.py`. Run tests using `python -m pytest tests/` after removal, and they passed 100% cleanly.

---
*PR created automatically by Jules for task [15314947510292667640](https://jules.google.com/task/15314947510292667640) started by @2fst4u*