### PR TITLE
🧹 Sweep: Remove unused `pace_std` calculation in `simulate.py`

### DIFF
--- a/f1pred/simulate.py
+++ b/f1pred/simulate.py
@@ -41,7 +41,6 @@ def simulate_grid(
         return np.array([]).reshape(0, 0), np.array([]), np.array([]).reshape(0, 0)
     
     # Calculate noise scale based on pace spread
-    pace_std = float(np.std(pace_index))
     pace_range = float(np.ptp(pace_index))  # max - min
     
     if pace_range > 0.01:


### PR DESCRIPTION
💡 **What:**
Removed the `pace_std = float(np.std(pace_index))` variable calculation in `f1pred/simulate.py`.

🎯 **Why:**
This variable was declared and computed but never read anywhere in the simulation logic. The scaling relies solely on `pace_range` instead. Removing it saves a tiny bit of computation and cleans up the code block, leaving the application functioning exactly as it did before. 

🔬 **Verification:**
1. Ran global workspace text search (`grep -rn pace_std f1pred/`) to guarantee it's fully gone.
2. Ran `ruff check f1pred/simulate.py` with zero issues.
3. Ran the full test suite (`make test`), and all 157 tests passed successfully.

---
*PR created automatically by Jules for task [16379130809570461761](https://jules.google.com/task/16379130809570461761) started by @2fst4u*