### PR TITLE
📚 Archivist: Remove obsolete OpenF1 references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The app fetches data from free, public APIs:
 
 - **[Jolpica F1](https://github.com/jolpica/jolpica-f1)** – Schedules, results, standings (Ergast-compatible)
 - **[Open-Meteo](https://open-meteo.com/)** – Weather forecasts and historical weather
-- **[OpenF1](https://openf1.org/)** – Session timing data (historical only)
+
 - **[FastF1](https://theoehrly.github.io/Fast-F1/)** – Detailed timing and telemetry fallback
 
 ## How It Works
@@ -108,7 +108,6 @@ python main.py --backtest
 
 ## Known Limitations
 
-- **No real-time data** – OpenF1 is used for historical data only, not live timing
 - **Weather is approximate** – Forecasts are aggregated around session windows
 - **DNF model is basic** – Uses historical base rates, not detailed reliability analysis
 - **First race of season** – Limited data for brand new driver/team combinations
@@ -127,7 +126,6 @@ f1pred/
 └── data/           # API clients
     ├── jolpica.py
     ├── open_meteo.py
-    ├── openf1.py
     └── fastf1_backend.py
 ```
 
@@ -146,7 +144,7 @@ python main.py --round next
 ```
 
 **Missing actuals for sprint qualifying?**
-Enable OpenF1 and/or install FastF1 in `config.yaml`.
+Enable FastF1 in `config.yaml`.
 
 **Rate limiting errors?**
 The built-in cache and retry logic should handle most cases. Try increasing `live_refresh_seconds` or clearing the `.cache/` directory.


### PR DESCRIPTION
💡 Problem: `README.md` contained several inaccurate claims, stating that the project used `OpenF1` as a data source for historical session timing, referenced an `openf1.py` script that did not exist in the codebase, and suggested enabling `OpenF1` in the configuration as a troubleshooting step.
🎯 Fix: Removed all references to `OpenF1` from the `Data Sources`, `Known Limitations`, and `Project Structure` sections. Updated the troubleshooting section to only reference `FastF1`.
🧪 Verification: Confirmed absence of `openf1` files via grep/ls (`ls f1pred/data/`), ran test suite (`python -m pytest tests/`), and verified `FastF1` exists as the current alternative.
🔎 Scope: This PR contains ONLY documentation changes.

---
*PR created automatically by Jules for task [5934953990396085108](https://jules.google.com/task/5934953990396085108) started by @2fst4u*