### PR TITLE
🧪 Spec: Add test for empty simulation grid

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,6 @@ omit = [
 # Locked in gain from util.py tests (39.04% -> 46.69%)
 # Locked in gain from ranking.py tests (46.69% -> 46.75%)
 # Locked in gain from metrics.py edge case tests (46.75% -> 46.96%)
-fail_under = 46.96
+# Locked in gain from simulate.py empty grid tests (46.96% -> 46.98%)
+fail_under = 46.98
 show_missing = true

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -79,3 +79,14 @@ def test_simulate_grid_no_pairwise():
 
     # Pairwise should be empty (since we returned empty array)
     assert pairwise.size == 0
+
+def test_simulate_grid_empty():
+    """Test that an empty grid returns empty arrays of correct shapes."""
+    pace_index = np.array([])
+    dnf_prob = np.array([])
+
+    prob_matrix, mean_pos, pairwise = simulate_grid(pace_index, dnf_prob, draws=100)
+
+    assert prob_matrix.shape == (0, 0)
+    assert mean_pos.shape == (0,)
+    assert pairwise.shape == (0, 0)


### PR DESCRIPTION
💡 What: Added `test_simulate_grid_empty` in `tests/test_simulate.py` and bumped the coverage `fail_under` from 46.96% to 46.98% in `pyproject.toml`.
🎯 Why: The edge case for an empty grid (`len(pace_index) == 0`) returning empty result arrays in `f1pred/simulate.py` was previously uncovered. This test ensures the function gracefully handles empty inputs.
📈 Ratchet: Increased statement coverage threshold by 0.02% to lock in the gain from this new test.

---
*PR created automatically by Jules for task [16178944048193049108](https://jules.google.com/task/16178944048193049108) started by @2fst4u*