### PR TITLE
🧹 Sweep: Remove dead code in f1pred/calibrate.py

### DIFF
--- a/f1pred/calibrate.py
+++ b/f1pred/calibrate.py
@@ -284,7 +284,6 @@ class CalibrationManager:
                 # GBM Score
                 # X_evt might need alignment? pipeline handles it
                 try:
-                    features_used = gbm_pipe.named_steps['pre'].get_feature_names_out() if hasattr(gbm_pipe.named_steps['pre'], 'get_feature_names_out') else None
                     # Sklearn pipeline applied to DF works by column name usually
                     pace_hat = gbm_pipe.predict(X_evt)
                     


### PR DESCRIPTION
💡 What: Removed the unused `features_used` variable and the `get_feature_names_out()` call used to assign it in `f1pred/calibrate.py`.

🎯 Why: The variable was completely unused (dead code). The method `get_feature_names_out()` simply inspects the names and causes no side effects. Removing this cleans up the file without impacting logic.

🔬 Verification: The unused variable was found by `ruff check .` explicitly as an `F841` violation. After removal, tests successfully ran and passed, confirming no regression.

---
*PR created automatically by Jules for task [13850509265658878209](https://jules.google.com/task/13850509265658878209) started by @2fst4u*