### PR TITLE
📚 Archivist: Fix local test installation dependencies in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thank you for your interest in contributing to F1 Predictor!
 4. Activate it:
    - Windows: `.venv\Scripts\activate`
    - Linux/macOS: `source .venv/bin/activate`
-5. Install dependencies: `pip install -r requirements.txt pytest pytest-cov`
+5. Install dependencies: `pip install -r requirements.txt pytest pytest-cov httpx`
 
 ## Making Changes
 


### PR DESCRIPTION
This PR adds `httpx` to the `pip install` instructions in `CONTRIBUTING.md`.

*   **💡 Problem:** The manual installation step for local testing in `CONTRIBUTING.md` lacked `httpx`, which is a requirement for running tests correctly (as visible in the `.github/workflows/tests.yml` CI pipeline where `httpx` is explicitly installed). Contributors attempting to run `make test` as instructed would encounter `ModuleNotFoundError` for `httpx`.
*   **🎯 Fix:** Updated the dependency command in `CONTRIBUTING.md` to `pip install -r requirements.txt pytest pytest-cov httpx`, perfectly matching the CI workflow and reality.
*   **🧪 Verification:** Ran the test suite using `make test` locally after applying this, with full verification that the local install command matches `.github/workflows/tests.yml`.
*   **🔎 Scope:** Only modifies `CONTRIBUTING.md`. No application code, behavior, or pipelines were altered.

---
*PR created automatically by Jules for task [11894608561941638604](https://jules.google.com/task/11894608561941638604) started by @2fst4u*