### PR TITLE
Enforce test success before release and docker build steps

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,11 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  test:
+    uses: ./.github/workflows/tests.yml
+
   build-and-push:
+    needs: [test]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,11 @@ on:
         default: patch
 
 jobs:
+  test:
+    uses: ./.github/workflows/tests.yml
+
   release:
+    needs: [test]
     runs-on: ubuntu-latest
     # Skip if push was a tag or if commit message contains [skip release]
     if: >-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: Tests
 
 on:
+  workflow_call:
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
This change reconfigures the GitHub Actions workflows to ensure that both the Docker image build (on PRs) and the full release process (on merge to main) are gated by successful test execution.

1. `.github/workflows/tests.yml` now supports both `workflow_call` (making it reusable) and `pull_request` triggers.
2. `.github/workflows/docker-publish.yml` now includes a `test` job that calls the reusable tests workflow and ensures the `build-and-push` job `needs: [test]`.
3. `.github/workflows/release.yml` now includes a `test` job that calls the reusable tests workflow and ensures the `release` job `needs: [test]`.

Fixes #133

---
*PR created automatically by Jules for task [13868802115335153429](https://jules.google.com/task/13868802115335153429) started by @2fst4u*