### PR TITLE
Fix Matplotlib permission denied in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ FROM python:3.12-slim
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    DEBIAN_FRONTEND=noninteractive
+    DEBIAN_FRONTEND=noninteractive \
+    MPLCONFIGDIR=/app/.cache/matplotlib
 
 WORKDIR /app
 
@@ -52,7 +53,7 @@ RUN pip install --no-cache-dir *.whl && rm *.whl
 COPY main.py config.yaml calibration_weights.json ./
 
 # Create cache directories with appropriate permissions
-RUN mkdir -p .cache/http_cache .cache/fastf1 && \
+RUN mkdir -p .cache/http_cache .cache/fastf1 .cache/matplotlib && \
     chmod -R 777 .cache
 
 # Expose the port the app runs on


### PR DESCRIPTION
The Docker image was failing on startup with a permission error: "mkdir -p failed for path /.config/matplotlib: [errno 13] permission denied: '/.config'". This is because matplotlib (imported by fastf1) attempts to create a configuration directory in the user's home directory, which in many Docker environments (especially when running as non-root) points to the root (/) where the user lacks write permissions.

This PR fixes the issue by:
1.  Setting the `MPLCONFIGDIR` environment variable to `/app/.cache/matplotlib` in the `Dockerfile`.
2.  Explicitly creating the `/app/.cache/matplotlib` directory and ensuring it has `777` permissions during the build process, allowing any user running the container to write to it.

Verified by running the full test suite (`make test`) which passed (179 tests, 49.90% coverage). Manual static analysis of the `Dockerfile` confirms the fix aligns with standard practices for matplotlib in containerized environments.

Fixes #138

---
*PR created automatically by Jules for task [417787577934081274](https://jules.google.com/task/417787577934081274) started by @2fst4u*