### PR TITLE
📚 Archivist: Replace make test phantom command with explicit pytest execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ When a release tag is created, Docker images get these tags on `ghcr.io/2fst4u/f
 ## Testing
 
 ```bash
-make test                              # Run full test suite
+python -m pytest --cov=f1pred tests/ -v  # Run full test suite
 python -m pytest tests/test_release_config.py -v  # Validate release infrastructure
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Thank you for your interest in contributing to F1 Predictor!
 1. Create a feature branch: `git checkout -b feature/your-feature-name`
 2. Make your changes
 3. Test that the tool still works: `python main.py --round next`
-4. Run the test suite: `make test`
+4. Run the test suite: `python -m pytest --cov=f1pred tests/ -v`
 5. Commit your changes with a clear message
 6. Push to your fork
 7. Open a Pull Request
@@ -34,7 +34,7 @@ Thank you for your interest in contributing to F1 Predictor!
 
 Before submitting, ensure:
 - The tool runs without errors (`python main.py --round next`)
-- All tests pass locally (`make test`)
+- All tests pass locally (`python -m pytest --cov=f1pred tests/ -v`)
 - Code coverage does not drop below the required threshold
 
 ## Releasing


### PR DESCRIPTION
💡 Problem: The documentation (`CONTRIBUTING.md` and `AGENTS.md`) advised contributors to use the phantom `make test` command, which abstracts away the critical `python -m pytest` environment and local module resolution needed for reliable execution as documented in `.jules/archivist.md`.
🎯 Fix: Replaced `make test` with the explicit, copy-pasteable command `python -m pytest --cov=f1pred tests/ -v`.
🧪 Verification: Read the updated files to confirm replacements. Ran `python -m pytest --cov=f1pred tests/ -v` successfully locally.
🔎 Scope: Documentation only (`CONTRIBUTING.md`, `AGENTS.md`).

---
*PR created automatically by Jules for task [12891909724260048141](https://jules.google.com/task/12891909724260048141) started by @2fst4u*