### PR TITLE
Fix container startup failure due to missing os import

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ Examples:
 """
 
 import argparse
+import os
 
 from colorama import Fore, Style
 import sys


### PR DESCRIPTION
The f1predictor container failed to start because main.py was missing a required import for the 'os' module, leading to a NameError when checking for the configuration file at /config/config.yaml. This change adds the missing import to main.py.

Fixes #148

---
*PR created automatically by Jules for task [15065898231310006527](https://jules.google.com/task/15065898231310006527) started by @2fst4u*