### PR TITLE
Fix container configuration shadowing in Kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,9 +65,10 @@ RUN mkdir -p /config .cache/matplotlib && \
 
 # Copy only required runtime files
 COPY main.py ./
-COPY config.yaml calibration_weights.json /config/
-# Symlink for local fallback if needed
-RUN ln -s /config/config.yaml ./config.yaml
+# We copy defaults to /app so they are available even if /config is shadowed by a volume
+COPY config.yaml calibration_weights.json ./
+# Also copy to /config for cases where no volume is mounted
+RUN cp config.yaml calibration_weights.json /config/
 
 # Expose the port the app runs on
 EXPOSE 8000

--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ Examples:
 
 import argparse
 import os
+import shutil
 
 from colorama import Fore, Style
 import sys
@@ -88,8 +89,28 @@ def main() -> None:
     # Conventional config search order
     config_path = args.config
     if config_path is None:
-        if os.path.exists("/config/config.yaml"):
-            config_path = "/config/config.yaml"
+        # Check if /config exists and is writable (likely a mounted volume)
+        if os.path.isdir("/config"):
+            if os.path.exists("/config/config.yaml"):
+                config_path = "/config/config.yaml"
+            elif os.access("/config", os.W_OK):
+                # /config exists but is empty/missing config.yaml - bootstrap it if we have defaults
+                # This handles the case where a PVC is mounted but empty
+                logger.info("Bootstrapping /config directory with default configuration")
+                for f in ["config.yaml", "calibration_weights.json"]:
+                    if os.path.exists(f) and not os.path.exists(os.path.join("/config", f)):
+                        try:
+                            shutil.copy2(f, "/config/")
+                        except Exception as e:
+                            # Non-fatal, we'll fall back to local config
+                            logger.warning(f"Failed to bootstrap {f} to /config: {e}")
+
+                if os.path.exists("/config/config.yaml"):
+                    config_path = "/config/config.yaml"
+                else:
+                    config_path = "config.yaml"
+            else:
+                config_path = "config.yaml"
         else:
             config_path = "config.yaml"
 


### PR DESCRIPTION
This change addresses the [Errno 2] error when running the f1predictor container in Kubernetes with a volume mounted at /config. The issue was caused by the volume shadowing the default configuration files in the image and breaking a symbolic link. 

The fix involves:
1. Dockerfile update: Files are now copied directly instead of using symlinks.
2. main.py update: Added logic to bootstrap empty /config volumes with default files at runtime, ensuring the application can start and use the persistent storage for its cache and configuration.

Fixes #150

---
*PR created automatically by Jules for task [11749296151815737154](https://jules.google.com/task/11749296151815737154) started by @2fst4u*