### PR TITLE
Fix SyntaxError in main.py by moving global logger declaration

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,6 +84,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    global logger
     args = parse_args()
 
     # Conventional config search order
@@ -121,7 +122,6 @@ def main() -> None:
     configure_logging(log_level)
     
     # Re-get logger after configuration
-    global logger
     logger = get_logger(__name__)
 
     # Input validation (UX Improvement)


### PR DESCRIPTION
The issue was caused by the `logger` variable being used in `main.py` (for bootstrapping logging) before it was declared as `global`. In Python, if a variable is declared `global` anywhere in a function, it is treated as a global variable for the entire scope of that function. However, using it before the `global` statement results in a `SyntaxError`.

I moved the `global logger` declaration to the very beginning of the `main()` function to ensure all subsequent uses are valid. I also removed the redundant `global` declaration that was further down in the function.

Verification:
- Ran `python3 -m py_compile main.py` to check for syntax errors.
- Ran `make test` to ensure all unit tests pass and no regressions were introduced.
- Verified that the reported error no longer occurs.

Fixes #152

---
*PR created automatically by Jules for task [3110161706515057544](https://jules.google.com/task/3110161706515057544) started by @2fst4u*