### PR TITLE
Fix invalid season validation in resolve_event

### DIFF
--- a/f1pred/predict.py
+++ b/f1pred/predict.py
@@ -32,7 +32,12 @@ logger = get_logger(__name__)
 
 
 def resolve_event(jc: JolpicaClient, season: Optional[str], rnd: str) -> Tuple[int, int, Dict[str, Any]]:
-    """Resolve season/round to use. Never raises; falls back to current/last if needed."""
+    """Resolve season/round to use. Falls back to current/last if needed."""
+    # Explicitly validate inputs before the fallback try-block to catch fundamentally invalid requests
+    if season is not None and str(season).lower() != "current":
+        jc._validate_season(str(season))
+    jc._validate_round(str(rnd))
+
     try:
         if season is None or (isinstance(season, str) and season.lower() == "current"):
             if rnd == "next":


### PR DESCRIPTION
This change fixes a test failure where invalid season parameters in the `/api/predict` endpoint incorrectly returned a 200 OK status instead of a 500 error. The fix involves adding explicit validation calls for season and round in the `resolve_event` function within `f1pred/predict.py`, ensuring that invalid inputs raise a `ValueError` before the function's internal fallback logic can catch and suppress it.

Fixes #157

---
*PR created automatically by Jules for task [15898541059952183205](https://jules.google.com/task/15898541059952183205) started by @2fst4u*