### PR TITLE
🧹 Sweep: Remove unused imports and variables

### DIFF
--- a/f1pred/data/open_meteo.py
+++ b/f1pred/data/open_meteo.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 
 import pandas as pd
 
-from ..util import session_with_retries, http_get_json, get_logger, safe_float
+from ..util import session_with_retries, http_get_json, get_logger
 
 logger = get_logger(__name__)
 

--- a/f1pred/features.py
+++ b/f1pred/features.py
@@ -8,7 +8,6 @@ teammate comparisons.
 from __future__ import annotations
 from typing import Dict, Any, List, Tuple, Optional, Union
 from datetime import datetime, timedelta, timezone
-from collections import defaultdict
 from pathlib import Path
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed

--- a/f1pred/models.py
+++ b/f1pred/models.py
@@ -13,7 +13,7 @@ from sklearn.preprocessing import StandardScaler, OneHotEncoder
 from sklearn.pipeline import Pipeline
 from sklearn.compose import ColumnTransformer
 from sklearn.impute import SimpleImputer
-from sklearn.ensemble import GradientBoostingRegressor, GradientBoostingClassifier
+from sklearn.ensemble import GradientBoostingRegressor
 
 # Suppress harmless sklearn warning about feature names when using preprocessing pipelines
 warnings.filterwarnings("ignore", message="X does not have valid feature names")

--- a/f1pred/util.py
+++ b/f1pred/util.py
@@ -330,7 +330,7 @@ class StatusSpinner:
 
         return self
 
-    def __exit__(self, exc_type, exc_value, exc_traceback):
+    def __exit__(self, exc_type, *_):
         self.running = False
         if self.thread:
             self.thread.join()

--- a/f1pred/web.py
+++ b/f1pred/web.py
@@ -10,8 +10,6 @@ import math
 from fastapi import FastAPI, Request, Query, HTTPException
 from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
-from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel
 
 from .config import AppConfig
 from .util import get_logger, init_caches, ensure_dirs, __version__

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -165,7 +165,7 @@ class TestComputeEventMetrics:
 class TestComputeEventMetricsExceptions:
     @patch('f1pred.metrics.spearmanr', side_effect=ValueError("spearman error"))
     @patch('f1pred.metrics.kendalltau', side_effect=ValueError("kendall error"))
-    def test_spearman_kendall_exceptions(self, mock_kendall, mock_spearman):
+    def test_spearman_kendall_exceptions(self, *_):
         # We need this to verify behavior: if scipy functions fail due to some reason
         # (like identical values causing warnings/errors in older versions or edge cases)
         # the metric should gracefully return NaN rather than crashing the evaluation.


### PR DESCRIPTION
### 💡 What:
Removed multiple unused imports and variables across the `f1pred` and `tests` directories. Specifically:
- `f1pred/util.py`: `exc_traceback`, `exc_value` in `StatusSpinner.__exit__`.
- `tests/test_metrics.py`: `mock_kendall`, `mock_spearman` in `test_spearman_kendall_exceptions`.
- `f1pred/data/open_meteo.py`: `safe_float` import.
- `f1pred/features.py`: `defaultdict` import.
- `f1pred/models.py`: `GradientBoostingClassifier` import.
- `f1pred/web.py`: `StaticFiles`, `BaseModel` imports.

### 🎯 Why:
To reduce visual clutter and keep the codebase tidy and strictly relevant. These variables and imports were provably unused according to linter analyses (flake8 and vulture) and manual codebase inspection. By ignoring unused method arguments using `*_` in specific places, we conform perfectly to expected signatures while telling Python the values aren't needed.

### 🔬 Verification:
- Ran `flake8 .` and `vulture . --min-confidence 100`, which correctly identified the unused variables.
- After cleanup, both commands reported zero dead code inside `f1pred`.
- Ran the full test suite (`pytest tests/`) to ensure no functionality or mock decorators broke due to the refactoring. Test suite passed.

---
*PR created automatically by Jules for task [2704341570922587781](https://jules.google.com/task/2704341570922587781) started by @2fst4u*