### PR TITLE
Reduce column padding and spacing on mobile view

### DIFF
--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -51,7 +51,7 @@
             </div>
         </header>
 
-        <main class="container mx-auto p-4 md:p-8">
+        <main class="container mx-auto px-2 py-4 md:p-8">
             <!-- Controls -->
             <div class="card p-6 mb-8 shadow-xl">
                 <div class="grid grid-cols-1 md:grid-cols-4 gap-6 items-end">
@@ -142,8 +142,8 @@
                         <!-- Weather Info -->
                         <div class="grid grid-cols-3 md:grid-cols-5 gap-2 sm:gap-4 mb-6">
                             <template x-if="data.weather && data.weather.temp_mean">
-                                <div class="card p-2 md:p-3 flex items-center space-x-2 md:space-x-3">
-                                    <div class="text-xl md:text-2xl text-yellow-500"><i class="fas fa-thermometer-half"></i></div>
+                                <div class="card p-1 md:p-3 flex items-center space-x-1 md:space-x-3">
+                                    <div class="text-lg md:text-2xl text-yellow-500"><i class="fas fa-thermometer-half"></i></div>
                                     <div>
                                         <div class="text-[10px] md:text-xs text-gray-400 uppercase">Temp</div>
                                         <div class="font-bold text-xs md:text-base" x-text="Math.round(data.weather.temp_mean) + '°C'"></div>
@@ -151,8 +151,8 @@
                                 </div>
                             </template>
                             <template x-if="data.weather && data.weather.rain_sum !== undefined">
-                                <div class="card p-2 md:p-3 flex items-center space-x-2 md:space-x-3">
-                                    <div class="text-xl md:text-2xl text-blue-500"><i class="fas fa-cloud-rain"></i></div>
+                                <div class="card p-1 md:p-3 flex items-center space-x-1 md:space-x-3">
+                                    <div class="text-lg md:text-2xl text-blue-500"><i class="fas fa-cloud-rain"></i></div>
                                     <div>
                                         <div class="text-[10px] md:text-xs text-gray-400 uppercase">Rain</div>
                                         <div class="font-bold text-xs md:text-base" x-text="data.weather.rain_sum.toFixed(1) + 'mm'"></div>
@@ -160,8 +160,8 @@
                                 </div>
                             </template>
                             <template x-if="data.weather && data.weather.wind_mean">
-                                <div class="card p-2 md:p-3 flex items-center space-x-2 md:space-x-3">
-                                    <div class="text-xl md:text-2xl text-gray-400"><i class="fas fa-wind"></i></div>
+                                <div class="card p-1 md:p-3 flex items-center space-x-1 md:space-x-3">
+                                    <div class="text-lg md:text-2xl text-gray-400"><i class="fas fa-wind"></i></div>
                                     <div>
                                         <div class="text-[10px] md:text-xs text-gray-400 uppercase">Wind</div>
                                         <div class="font-bold text-xs md:text-base" x-text="Math.round(data.weather.wind_mean) + 'km/h'"></div>
@@ -176,38 +176,38 @@
                                 <table class="w-full text-left">
                                     <thead>
                                         <tr class="bg-gray-800 text-[10px] sm:text-xs font-bold text-gray-400 uppercase tracking-wider">
-                                            <th class="p-2 sm:p-4 w-8 sm:w-12 text-center">Pos</th>
-                                            <th class="p-2 sm:p-4">Driver</th>
-                                            <th class="p-2 sm:p-4 hidden md:table-cell">Team</th>
-                                            <th class="p-2 sm:p-4 text-center" x-show="hasGrid(sess)">Grid</th>
-                                            <th class="p-2 sm:p-4">
+                                            <th class="px-1 py-2 sm:p-4 w-8 sm:w-12 text-center">Pos</th>
+                                            <th class="px-1 py-2 sm:p-4">Driver</th>
+                                            <th class="px-1 py-2 sm:p-4 hidden md:table-cell">Team</th>
+                                            <th class="px-1 py-2 sm:p-4 text-center" x-show="hasGrid(sess)">Grid</th>
+                                            <th class="px-1 py-2 sm:p-4">
                                                 <span class="hidden sm:inline">Win Prob</span>
                                                 <span class="sm:hidden">Win %</span>
                                             </th>
-                                            <th class="p-2 sm:p-4">
+                                            <th class="px-1 py-2 sm:p-4">
                                                 <span class="hidden sm:inline">Podium</span>
                                                 <span class="sm:hidden">Top 3</span>
                                             </th>
-                                            <th class="p-2 sm:p-4">DNF</th>
-                                            <th class="p-2 sm:p-4 text-right">Actual</th>
+                                            <th class="px-1 py-2 sm:p-4">DNF</th>
+                                            <th class="px-1 py-2 sm:p-4 text-right">Actual</th>
                                         </tr>
                                     </thead>
                                     <tbody class="divide-y divide-gray-800">
                                         <template x-for="(p, index) in data.predictions" :key="p.driverId">
                                             <tr class="hover:bg-gray-800 transition group text-sm sm:text-base" :class="getTeamClass(p.constructorName)">
-                                                <td class="p-2 sm:p-4 text-center font-black italic text-base sm:text-lg"
+                                                <td class="px-1 py-2 sm:p-4 text-center font-black italic text-base sm:text-lg"
                                                     :class="index < 3 ? 'text-yellow-500' : 'text-gray-500'"
                                                     x-text="p.predicted_position"></td>
-                                                <td class="p-2 sm:p-4">
-                                                    <div class="flex items-center space-x-2 sm:space-x-3">
+                                                <td class="px-1 py-2 sm:p-4">
+                                                    <div class="flex items-center space-x-1 sm:space-x-3">
                                                         <div class="font-bold uppercase tracking-tighter" x-text="p.code || '???'"></div>
-                                                        <div class="font-semibold text-gray-200 group-hover:text-white truncate max-w-[80px] sm:max-w-none" x-text="p.name"></div>
+                                                        <div class="font-semibold text-gray-200 group-hover:text-white truncate max-w-[60px] sm:max-w-none" x-text="p.name"></div>
                                                     </div>
                                                 </td>
-                                                <td class="p-2 sm:p-4 hidden md:table-cell">
+                                                <td class="px-1 py-2 sm:p-4 hidden md:table-cell">
                                                     <span class="text-sm text-gray-400" x-text="p.constructorName"></span>
                                                 </td>
-                                                <td class="p-2 sm:p-4 text-center" x-show="hasGrid(sess)">
+                                                <td class="px-1 py-2 sm:p-4 text-center" x-show="hasGrid(sess)">
                                                     <div class="flex flex-col items-center">
                                                         <span class="font-bold" x-text="p.grid || '--'"></span>
                                                         <template x-if="p.grid && p.grid != p.predicted_position">
@@ -218,8 +218,8 @@
                                                         </template>
                                                     </div>
                                                 </td>
-                                                <td class="p-2 sm:p-4">
-                                                    <div class="w-16 sm:w-24">
+                                                <td class="px-1 py-2 sm:p-4">
+                                                    <div class="w-12 sm:w-24">
                                                         <div class="flex justify-between text-[10px] mb-0.5 sm:mb-1">
                                                             <span x-text="(p.p_win * 100).toFixed(1) + '%'"></span>
                                                         </div>
@@ -228,8 +228,8 @@
                                                         </div>
                                                     </div>
                                                 </td>
-                                                <td class="p-2 sm:p-4">
-                                                    <div class="w-16 sm:w-24">
+                                                <td class="px-1 py-2 sm:p-4">
+                                                    <div class="w-12 sm:w-24">
                                                         <div class="flex justify-between text-[10px] mb-0.5 sm:mb-1">
                                                             <span x-text="(p.p_top3 * 100).toFixed(1) + '%'"></span>
                                                         </div>
@@ -238,8 +238,8 @@
                                                         </div>
                                                     </div>
                                                 </td>
-                                                <td class="p-2 sm:p-4">
-                                                    <div class="w-16 sm:w-24">
+                                                <td class="px-1 py-2 sm:p-4">
+                                                    <div class="w-12 sm:w-24">
                                                         <div class="flex justify-between text-[10px] mb-0.5 sm:mb-1">
                                                             <span x-text="(p.p_dnf * 100).toFixed(1) + '%'"></span>
                                                         </div>
@@ -248,7 +248,7 @@
                                                         </div>
                                                     </div>
                                                 </td>
-                                                <td class="p-2 sm:p-4 text-right">
+                                                <td class="px-1 py-2 sm:p-4 text-right">
                                                     <template x-if="p.actual_position">
                                                         <span class="font-bold px-2 py-1 rounded"
                                                               :class="p.actual_position == p.predicted_position ? 'bg-green-600' : (Math.abs(p.actual_position - p.predicted_position) <= 2 ? 'bg-blue-600' : 'bg-gray-700')"


### PR DESCRIPTION
This PR optimizes the Web UI for mobile devices by reducing excessive padding and horizontal spacing in the results table and weather information cards.

Key changes:
- `main` container: `p-4` -> `px-2 py-4` (mobile)
- Weather cards: `p-2` -> `p-1`, `space-x-2` -> `space-x-1`, icon `text-xl` -> `text-lg` (mobile)
- Table cells: `p-2` -> `px-1 py-2` (mobile)
- Driver name truncation: `max-w-[80px]` -> `max-w-[60px]` (mobile)
- Probability column width: `w-16` -> `w-12` (mobile)

Visual verification was performed using Playwright on an iPhone SE viewport (375px), confirming that the table is now fully visible and horizontal scrolling is minimized.

Fixes #168

---
*PR created automatically by Jules for task [11250036995273970238](https://jules.google.com/task/11250036995273970238) started by @2fst4u*