### PR TITLE
🛡️ Sentinel: [MEDIUM] Add defensive security headers to Web UI

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -50,3 +50,8 @@
 **Vulnerability:** The FastAPI endpoints in `web.py` caught generic exceptions and returned `str(e)` directly to the client in the 500 response body (e.g., via `HTTPException(status_code=500, detail=str(e))`). This could leak sensitive internal information, such as file paths, validation patterns, or internal API structures.
 **Learning:** Catching generic exceptions and exposing their string representation to end-users violates the principle of failing securely. Error details should be logged internally, while generic messages should be returned to clients.
 **Prevention:** Ensure that global exception handlers or endpoint-specific `except Exception` blocks log the full stack trace server-side (using `logger.exception`) but return a static, generic error message (like "Internal server error") to the client.
+
+## 2024-03-01 - [Missing Security Headers in FastAPI App]
+**Vulnerability:** The FastAPI application serving the Web UI lacked fundamental security headers (like X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Strict-Transport-Security, and Content-Security-Policy), leaving it susceptible to framing (Clickjacking), MIME-sniffing attacks, and potentially cross-site scripting (XSS).
+**Learning:** FastAPI, unlike some opinionated web frameworks, does not ship with built-in or default HTTP security headers middleware. It relies on the developer to explicitly configure these protections.
+**Prevention:** Implement a standard `BaseHTTPMiddleware` (or use `@app.middleware("http")`) across all web services to inject defensive HTTP headers. Always explicitly define a Content-Security-Policy (CSP) that adheres to the principle of least privilege, allowing only verified CDNs or local assets.

--- a/f1pred/web.py
+++ b/f1pred/web.py
@@ -23,6 +23,26 @@ logger = get_logger(__name__)
 app = FastAPI(title="F1 Prediction Web UI")
 _config: AppConfig = None
 
+@app.middleware("http")
+async def add_security_headers(request: Request, call_next):
+    response = await call_next(request)
+    # 🛡️ Sentinel: Defense in depth - Add security headers to prevent common web vulnerabilities
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["X-XSS-Protection"] = "1; mode=block"
+    response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+
+    # CSP: Allow self, CDNs for Tailwind/Alpine/FontAwesome, and inline scripts/styles for Alpine/Tailwind.
+    csp = (
+        "default-src 'self'; "
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.tailwindcss.com https://cdn.jsdelivr.net; "
+        "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com; "
+        "font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com; "
+        "connect-src 'self';"
+    )
+    response.headers["Content-Security-Policy"] = csp
+    return response
+
 # Templates
 templates = Jinja2Templates(directory=os.path.join(os.path.dirname(__file__), "templates"))
 


### PR DESCRIPTION
🛡️ **Sentinel: [MEDIUM] Security Headers Enhancement**

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The FastAPI application serving the Web UI lacked fundamental security headers (like X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Strict-Transport-Security, and Content-Security-Policy).
🎯 **Impact:** Without these headers, the application is susceptible to framing (Clickjacking), MIME-sniffing attacks, and potentially cross-site scripting (XSS) if vulnerabilities exist in the frontend rendering logic.
🔧 **Fix:** Implemented a global `@app.middleware("http")` hook in `f1pred/web.py` to automatically inject standard defensive HTTP headers into every response. A permissive but explicitly scoped `Content-Security-Policy` (CSP) was added to ensure necessary CDNs (Tailwind, Alpine, FontAwesome) function correctly while blocking untrusted origins.
✅ **Verification:** Verified by running the test suite (`python -m pytest --cov=f1pred tests/`) where all 191 tests passed successfully with total coverage of 54.38%. I also locally verified `test_web.py` specifically to ensure the middleware does not interrupt normal routing or SSE streaming.

*(Note: Cleaned up temporary patch files generated during implementation prior to commit).*

---
*PR created automatically by Jules for task [15266264280621728977](https://jules.google.com/task/15266264280621728977) started by @2fst4u*