### PR TITLE
Optimize mobile view columns in predictions table

### DIFF
--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -176,38 +176,38 @@
                                 <table class="w-full text-left">
                                     <thead>
                                         <tr class="bg-gray-800 text-[10px] sm:text-xs font-bold text-gray-400 uppercase tracking-wider">
-                                            <th class="px-1 py-2 sm:p-4 w-8 sm:w-12 text-center">Pos</th>
-                                            <th class="px-1 py-2 sm:p-4">Driver</th>
-                                            <th class="px-1 py-2 sm:p-4 hidden md:table-cell">Team</th>
-                                            <th class="px-1 py-2 sm:p-4 text-center" x-show="hasGrid(sess)">Grid</th>
-                                            <th class="px-1 py-2 sm:p-4">
+                                            <th class="px-0.5 py-2 sm:p-4 w-7 sm:w-12 text-center">Pos</th>
+                                            <th class="px-0.5 py-2 sm:p-4">Driver</th>
+                                            <th class="px-0.5 py-2 sm:p-4 hidden md:table-cell">Team</th>
+                                            <th class="px-0.5 py-2 sm:p-4 text-center" x-show="hasGrid(sess)">Grid</th>
+                                            <th class="px-0.5 py-2 sm:p-4">
                                                 <span class="hidden sm:inline">Win Prob</span>
                                                 <span class="sm:hidden">Win %</span>
                                             </th>
-                                            <th class="px-1 py-2 sm:p-4">
+                                            <th class="px-0.5 py-2 sm:p-4">
                                                 <span class="hidden sm:inline">Podium</span>
                                                 <span class="sm:hidden">Top 3</span>
                                             </th>
-                                            <th class="px-1 py-2 sm:p-4">DNF</th>
-                                            <th class="px-1 py-2 sm:p-4 text-right">Actual</th>
+                                            <th class="px-0.5 py-2 sm:p-4">DNF</th>
+                                            <th class="px-0.5 py-2 sm:p-4 text-right">Actual</th>
                                         </tr>
                                     </thead>
                                     <tbody class="divide-y divide-gray-800">
                                         <template x-for="(p, index) in data.predictions" :key="p.driverId">
                                             <tr class="hover:bg-gray-800 transition group text-sm sm:text-base" :class="getTeamClass(p.constructorName)">
-                                                <td class="px-1 py-2 sm:p-4 text-center font-black italic text-base sm:text-lg"
+                                                <td class="px-0.5 py-2 sm:p-4 text-center font-black italic text-base sm:text-lg"
                                                     :class="index < 3 ? 'text-yellow-500' : 'text-gray-500'"
                                                     x-text="p.predicted_position"></td>
-                                                <td class="px-1 py-2 sm:p-4">
+                                                <td class="px-0.5 py-2 sm:p-4">
                                                     <div class="flex items-center space-x-1 sm:space-x-3">
                                                         <div class="font-bold uppercase tracking-tighter" x-text="p.code || '???'"></div>
-                                                        <div class="font-semibold text-gray-200 group-hover:text-white truncate max-w-[60px] sm:max-w-none" x-text="p.name"></div>
+                                                        <div class="font-semibold text-gray-200 group-hover:text-white truncate max-w-[140px] sm:max-w-none" x-text="p.name"></div>
                                                     </div>
                                                 </td>
-                                                <td class="px-1 py-2 sm:p-4 hidden md:table-cell">
+                                                <td class="px-0.5 py-2 sm:p-4 hidden md:table-cell">
                                                     <span class="text-sm text-gray-400" x-text="p.constructorName"></span>
                                                 </td>
-                                                <td class="px-1 py-2 sm:p-4 text-center" x-show="hasGrid(sess)">
+                                                <td class="px-0.5 py-2 sm:p-4 text-center" x-show="hasGrid(sess)">
                                                     <div class="flex flex-col items-center">
                                                         <span class="font-bold" x-text="p.grid || '--'"></span>
                                                         <template x-if="p.grid && p.grid != p.predicted_position">
@@ -218,8 +218,8 @@
                                                         </template>
                                                     </div>
                                                 </td>
-                                                <td class="px-1 py-2 sm:p-4">
-                                                    <div class="w-12 sm:w-24">
+                                                <td class="px-0.5 py-2 sm:p-4">
+                                                    <div class="w-10 sm:w-24">
                                                         <div class="flex justify-between text-[10px] mb-0.5 sm:mb-1">
                                                             <span x-text="(p.p_win * 100).toFixed(1) + '%'"></span>
                                                         </div>
@@ -228,8 +228,8 @@
                                                         </div>
                                                     </div>
                                                 </td>
-                                                <td class="px-1 py-2 sm:p-4">
-                                                    <div class="w-12 sm:w-24">
+                                                <td class="px-0.5 py-2 sm:p-4">
+                                                    <div class="w-10 sm:w-24">
                                                         <div class="flex justify-between text-[10px] mb-0.5 sm:mb-1">
                                                             <span x-text="(p.p_top3 * 100).toFixed(1) + '%'"></span>
                                                         </div>
@@ -238,8 +238,8 @@
                                                         </div>
                                                     </div>
                                                 </td>
-                                                <td class="px-1 py-2 sm:p-4">
-                                                    <div class="w-12 sm:w-24">
+                                                <td class="px-0.5 py-2 sm:p-4">
+                                                    <div class="w-10 sm:w-24">
                                                         <div class="flex justify-between text-[10px] mb-0.5 sm:mb-1">
                                                             <span x-text="(p.p_dnf * 100).toFixed(1) + '%'"></span>
                                                         </div>
@@ -248,7 +248,7 @@
                                                         </div>
                                                     </div>
                                                 </td>
-                                                <td class="px-1 py-2 sm:p-4 text-right">
+                                                <td class="px-0.5 py-2 sm:p-4 text-right">
                                                     <template x-if="p.actual_position">
                                                         <span class="font-bold px-2 py-1 rounded"
                                                               :class="p.actual_position == p.predicted_position ? 'bg-green-600' : (Math.abs(p.actual_position - p.predicted_position) <= 2 ? 'bg-blue-600' : 'bg-gray-700')"


### PR DESCRIPTION
This change improves the mobile user experience of the predictions table by reducing excessive column spacing and allowing more room for driver names. Previously, names were being truncated even when there was available space. The horizontal padding has been reduced, and the driver name column's maximum width has been increased to ensure full names are visible on modern mobile devices without horizontal scrolling.

Fixes #171

---
*PR created automatically by Jules for task [4362892510826377416](https://jules.google.com/task/4362892510826377416) started by @2fst4u*