### PR TITLE
🧪 Spec: Fix and Add Test for exponential_weights object Series

### DIFF
--- a/f1pred/features.py
+++ b/f1pred/features.py
@@ -142,7 +142,15 @@ def exponential_weights(dates: Union[List[datetime], pd.Series], ref_date: datet
         else:
             # Vectorized path for non-datetime64 pandas Series (e.g. object dtype)
             # Note: dates should not contain NaT ideally, but fillna(0) handles it safely
-            ages = (ref_date - dates).dt.days.fillna(0).values.astype(float)
+            # Using astype('timedelta64[ns]') makes it compatible with .dt if needed,
+            # but standard subtraction gives timedeltas directly.
+            diff = ref_date - dates
+            # Object series with NaT might not support .dt directly unless converted to a timedelta type
+            try:
+                ages = diff.dt.days.fillna(0).values.astype(float)
+            except AttributeError:
+                # If diff is a Series of datetime.timedelta objects
+                ages = diff.apply(lambda x: x.days if pd.notna(x) else 0).values.astype(float)
     else:
         # Legacy path for lists
         ages = np.array([(ref_date - d).days if isinstance(d, datetime) else 0 for d in dates], dtype=float)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,5 +38,5 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 49.52
+fail_under = 49.61
 show_missing = true

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -70,6 +70,17 @@ def test_exponential_weights_list_input():
     assert np.isclose(weights[1], 0.5)
 
 
+def test_exponential_weights_object_series():
+    """Test object dtype handling in exponential weights."""
+    ref_date = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    # Series with object dtype containing datetime objects
+    dates_series = pd.Series([ref_date, ref_date - timedelta(days=10)], dtype=object)
+    weights = exponential_weights(dates_series, ref_date, half_life_days=10)
+
+    assert np.isclose(weights[0], 1.0)
+    assert np.isclose(weights[1], 0.5)
+
+
 def test_compute_form_indices(sample_historical_data):
     """Test form index calculation."""
     ref_date = datetime(2023, 3, 10, tzinfo=timezone.utc)


### PR DESCRIPTION
💡 What: Added a new unit test for `exponential_weights` in `tests/test_features.py` to test object dtype Series inputs and fixed an AttributeError crash inside `f1pred/features.py` where `.dt.days` fails on an object Series of timedeltas by adding a `try/except AttributeError` fallback. 

🎯 Why: The codebase uses pandas `.dt` accessors which fail completely if the series gets unexpectedly downcasted or parsed as an `object` type (e.g. native python datetimes that escape Pandas native datetime64 conversion). Fixing this and writing a test ensures stability across varying input types.

📈 Ratchet: Increased statement coverage threshold by 0.09% (from 49.52 to 49.61) to lock in the gain from this new test.

---
*PR created automatically by Jules for task [17878520122268369869](https://jules.google.com/task/17878520122268369869) started by @2fst4u*