### PR TITLE
🧹 Sweep: Remove unused variable `old` in concurrency tests

### DIFF
--- a/tests/test_security_concurrency.py
+++ b/tests/test_security_concurrency.py
@@ -23,7 +23,7 @@ def test_umask_race_condition(tmp_path):
     """
     # 1. Set a known initial umask (e.g. 022, standard for many systems)
     initial_umask = 0o022
-    old = os.umask(initial_umask)
+    os.umask(initial_umask)
 
     # Verify we set it correctly (umask returns PREVIOUS, so call again to read current, then restore)
     current = os.umask(initial_umask)


### PR DESCRIPTION
💡 What: Removed the unused variable assignment `old = os.umask(initial_umask)` in `tests/test_security_concurrency.py`, preserving the critical side-effect function call `os.umask(initial_umask)`.

🎯 Why: The variable `old` was assigned but never read anywhere in the test suite, representing dead code and clutter. The function `os.umask()` modifies the process state, so retaining the call itself is critical to the test logic, but capturing its return value into an unread variable is unnecessary.

🔬 Verification:
- `ruff check .` flagged the variable as `F841 Local variable old is assigned to but never used`.
- A manual review confirmed `old` was unreferenced in the rest of the function scope.
- Post-deletion, the full test suite (`make test`) and linter (`ruff check .`) ran and passed flawlessly, confirming the test behavior remains unchanged.

---
*PR created automatically by Jules for task [17118579016695424204](https://jules.google.com/task/17118579016695424204) started by @2fst4u*