### PR TITLE
Fix roster identity mismatch between FastF1 and Jolpica/Ergast

### DIFF
--- a/f1pred/features.py
+++ b/f1pred/features.py
@@ -411,6 +411,20 @@ def collect_historical_results(
     elif not df.empty:
         df["is_dnf"] = 0
 
+    # Safeguard: Check if roster driverIds have any overlap with collected history for the current season
+    if roster_set and not df.empty:
+        # Check overlap only in the target season to avoid false positives from past seasons
+        # (though history scan already does some of this)
+        current_season_hist = df[df["season"] == season]
+        if not current_season_hist.empty:
+            overlap = current_season_hist["driverId"].isin(roster_set).sum()
+            if overlap == 0:
+                logger.warning(
+                    f"[features] [history] CRITICAL: Roster of {len(roster_set)} drivers has ZERO overlap "
+                    f"with {season} history. Features will likely be neutral/ignored. "
+                    f"Check for ID mismatch (e.g. FastF1 vs Ergast IDs)."
+                )
+
     _HIST_CACHE[cache_key] = df.copy()
     alias_key = (season, tuple())
     if alias_key not in _HIST_CACHE:

--- a/f1pred/roster.py
+++ b/f1pred/roster.py
@@ -155,16 +155,65 @@ def _roster_from_round(jc: JolpicaClient, season: str, rnd: str) -> List[Dict]:
     return []
 
 
-def _roster_from_fastf1(season: int, rnd: int) -> List[Dict]:
+def _get_canonical_mapping(jc: JolpicaClient, season: str) -> Dict[str, Any]:
+    """Build lookup tables to map various identities to canonical Jolpica/Ergast IDs."""
+    try:
+        raw_entries = jc.get_season_entry_list(season)
+        if not raw_entries:
+            return {}
+
+        driver_map = {}
+        constructor_map = {}
+
+        for r in raw_entries:
+            drv = r.get("Driver", {})
+            cons = r.get("Constructor", {})
+
+            d_id = drv.get("driverId")
+            c_id = cons.get("constructorId")
+            c_name = cons.get("name")
+
+            if d_id:
+                # Map by Number
+                num = drv.get("permanentNumber")
+                if num:
+                    driver_map[str(num)] = d_id
+
+                # Map by Code (Abbreviation)
+                code = drv.get("code")
+                if code:
+                    driver_map[code.upper()] = d_id
+
+                # Map by Name (Normalised)
+                gn = drv.get("givenName", "")
+                fn = drv.get("familyName", "")
+                if gn and fn:
+                    name_key = f"{gn} {fn}".lower().strip()
+                    driver_map[name_key] = d_id
+
+            if c_id and c_name:
+                # Map by Name (Normalised)
+                constructor_map[c_name.lower().strip()] = c_id
+
+        return {
+            "drivers": driver_map,
+            "constructors": constructor_map
+        }
+    except Exception as e:
+        logger.warning(f"[roster] Failed to build canonical mapping: {e}")
+        return {}
+
+
+def _roster_from_fastf1(season: int, rnd: int, mapping: Optional[Dict] = None) -> List[Dict]:
     """Attempt to fetch roster from FastF1 (live timing)."""
     try:
         # Import here to avoid circular dependencies if not already imported
         from .data import fastf1_backend as ff1
-        
+
         ev = ff1.get_event(season, rnd)
         if ev is None:
             return []
-            
+
         # Try to load session (e.g., FP1)
         # FastF1 often requires a session to be loaded to get drivers
         try:
@@ -174,17 +223,50 @@ def _roster_from_fastf1(season: int, rnd: int) -> List[Dict]:
             results = sess.results
             if results is None or results.empty:
                 return []
-                
+
             roster = []
+            d_map = (mapping or {}).get("drivers", {})
+            c_map = (mapping or {}).get("constructors", {})
+
             for _, r in results.iterrows():
+                # Try to canonicalize driverId
+                abbr = r.get("Abbreviation")
+                num = r.get("DriverNumber")
+                gn = r.get("FirstName")
+                fn = r.get("LastName")
+
+                did = None
+                if abbr and abbr.upper() in d_map:
+                    did = d_map[abbr.upper()]
+                elif num and str(num) in d_map:
+                    did = d_map[str(num)]
+                elif gn and fn:
+                    name_key = f"{gn} {fn}".lower().strip()
+                    if name_key in d_map:
+                        did = d_map[name_key]
+
+                # Fallback to abbreviation if not mapped
+                if not did:
+                    did = abbr.lower() if abbr else None
+
+                # Try to canonicalize constructorId
+                tname = r.get("TeamName")
+                cid = None
+                if tname and tname.lower().strip() in c_map:
+                    cid = c_map[tname.lower().strip()]
+
+                # Fallback to normalised TeamName
+                if not cid:
+                    cid = tname.lower().replace(" ", "_") if tname else None
+
                 roster.append({
-                    "driverId": r["Abbreviation"].lower() if "Abbreviation" in r else None,
-                    "code": r.get("Abbreviation"),
-                    "givenName": r.get("FirstName"),
-                    "familyName": r.get("LastName"),
-                    "permanentNumber": str(r.get("DriverNumber")),
-                    "constructorId": r.get("TeamName", "").lower().replace(" ", "_"),
-                    "constructorName": r.get("TeamName"),
+                    "driverId": did,
+                    "code": abbr,
+                    "givenName": gn,
+                    "familyName": fn,
+                    "permanentNumber": str(num) if num else None,
+                    "constructorId": cid,
+                    "constructorName": tname,
                 })
             logger.info(f"[roster] Fetched {len(roster)} drivers from FastF1")
             return roster
@@ -224,7 +306,9 @@ def derive_roster(
         return same
 
     # 2. OPTION B: FastF1 (live timing, good for active weekends before results are posted)
-    roster = _roster_from_fastf1(s_int, r_int)
+    # Fetch mapping for canonicalization
+    mapping = _get_canonical_mapping(jc, season)
+    roster = _roster_from_fastf1(s_int, r_int, mapping=mapping)
     if roster:
         return roster
 

--- a/tests/test_roster_mapping.py
+++ b/tests/test_roster_mapping.py
@@ -1,0 +1,143 @@
+import pytest
+import pandas as pd
+from unittest.mock import MagicMock, patch
+from f1pred.roster import _get_canonical_mapping, _roster_from_fastf1
+
+def test_get_canonical_mapping():
+    jc = MagicMock()
+    jc.get_season_entry_list.return_value = [
+        {
+            "Driver": {
+                "driverId": "max_verstappen",
+                "permanentNumber": "1",
+                "code": "VER",
+                "givenName": "Max",
+                "familyName": "Verstappen"
+            },
+            "Constructor": {
+                "constructorId": "red_bull",
+                "name": "Red Bull Racing"
+            }
+        },
+        {
+            "Driver": {
+                "driverId": "lando_norris",
+                "permanentNumber": "4",
+                "code": "NOR",
+                "givenName": "Lando",
+                "familyName": "Norris"
+            },
+            "Constructor": {
+                "constructorId": "mclaren",
+                "name": "McLaren"
+            }
+        }
+    ]
+
+    mapping = _get_canonical_mapping(jc, "2024")
+
+    assert "drivers" in mapping
+    assert "constructors" in mapping
+
+    # Check driver mapping by various keys
+    assert mapping["drivers"]["1"] == "max_verstappen"
+    assert mapping["drivers"]["VER"] == "max_verstappen"
+    assert mapping["drivers"]["max verstappen"] == "max_verstappen"
+    assert mapping["drivers"]["4"] == "lando_norris"
+    assert mapping["drivers"]["NOR"] == "lando_norris"
+    assert mapping["drivers"]["lando norris"] == "lando_norris"
+
+    # Check constructor mapping
+    assert mapping["constructors"]["red bull racing"] == "red_bull"
+    assert mapping["constructors"]["mclaren"] == "mclaren"
+
+@patch("f1pred.data.fastf1_backend.get_event")
+def test_roster_from_fastf1_with_mapping(mock_get_event):
+    # Setup mock FastF1 results
+    mock_results = pd.DataFrame([
+        {
+            "Abbreviation": "VER",
+            "DriverNumber": 1,
+            "FirstName": "Max",
+            "LastName": "Verstappen",
+            "TeamName": "Red Bull Racing"
+        },
+        {
+            "Abbreviation": "NOR",
+            "DriverNumber": 4,
+            "FirstName": "Lando",
+            "LastName": "Norris",
+            "TeamName": "McLaren"
+        },
+        {
+            "Abbreviation": "BEA",
+            "DriverNumber": 38,
+            "FirstName": "Oliver",
+            "LastName": "Bearman",
+            "TeamName": "Ferrari"
+        }
+    ])
+
+    mock_sess = MagicMock()
+    mock_sess.results = mock_results
+
+    mock_event = MagicMock()
+    mock_event.get_session.return_value = mock_sess
+    mock_get_event.return_value = mock_event
+
+    # Canonical mapping
+    mapping = {
+        "drivers": {
+            "VER": "max_verstappen",
+            "NOR": "lando_norris",
+            "38": "bearman"
+        },
+        "constructors": {
+            "red bull racing": "red_bull",
+            "mclaren": "mclaren",
+            "ferrari": "ferrari"
+        }
+    }
+
+    roster = _roster_from_fastf1(2024, 1, mapping=mapping)
+
+    assert len(roster) == 3
+
+    # Check canonicalized IDs
+    ver = next(d for d in roster if d["code"] == "VER")
+    assert ver["driverId"] == "max_verstappen"
+    assert ver["constructorId"] == "red_bull"
+
+    nor = next(d for d in roster if d["code"] == "NOR")
+    assert nor["driverId"] == "lando_norris"
+    assert nor["constructorId"] == "mclaren"
+
+    bea = next(d for d in roster if d["code"] == "BEA")
+    assert bea["driverId"] == "bearman" # Mapped via number "38"
+    assert bea["constructorId"] == "ferrari"
+
+@patch("f1pred.data.fastf1_backend.get_event")
+def test_roster_from_fastf1_fallback(mock_get_event):
+    # Setup mock FastF1 results with no mapping
+    mock_results = pd.DataFrame([
+        {
+            "Abbreviation": "VER",
+            "DriverNumber": 1,
+            "FirstName": "Max",
+            "LastName": "Verstappen",
+            "TeamName": "Red Bull Racing"
+        }
+    ])
+
+    mock_sess = MagicMock()
+    mock_sess.results = mock_results
+
+    mock_event = MagicMock()
+    mock_event.get_session.return_value = mock_sess
+    mock_get_event.return_value = mock_event
+
+    roster = _roster_from_fastf1(2024, 1, mapping=None)
+
+    assert len(roster) == 1
+    assert roster[0]["driverId"] == "ver" # Fallback to lowercase abbreviation
+    assert roster[0]["constructorId"] == "red_bull_racing" # Fallback to normalized TeamName


### PR DESCRIPTION
The fix ensures that predictions remain stable regardless of the roster source by mapping FastF1 driver abbreviations and team names to the canonical Ergast/Jolpica IDs used throughout the historical feature pipeline. It also adds a critical warning to alert developers if an identity mismatch occurs.

Fixes #182

---
*PR created automatically by Jules for task [15815529835642846752](https://jules.google.com/task/15815529835642846752) started by @2fst4u*