### PR TITLE
Improve Season and Round Selection UI

### DIFF
--- a/f1pred/data/jolpica.py
+++ b/f1pred/data/jolpica.py
@@ -216,6 +216,14 @@ class JolpicaClient:
 
     # Schedules and events
 
+    def get_seasons(self) -> List[Dict[str, Any]]:
+        """Fetch all available seasons."""
+        pages = self._fetch_paginated_parallel("seasons.json")
+        all_seasons = []
+        for mr in pages:
+            all_seasons.extend(mr.get("SeasonTable", {}).get("Seasons", []) or [])
+        return all_seasons
+
     def get_season_schedule(self, season: str) -> List[Dict[str, Any]]:
         season = self._validate_season(season)
         js = self._get(f"{season}.json", params={"limit": 1000})

--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -57,13 +57,23 @@
                 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-6 items-end">
                     <div>
                         <label for="input-season" class="block text-xs font-bold text-gray-400 mb-1 uppercase tracking-wider">Season</label>
-                        <input id="input-season" type="text" x-model="params.season" placeholder="current"
-                               class="w-full bg-gray-800 border border-gray-700 rounded p-1.5 md:p-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-red-600">
+                        <select id="input-season" x-model="params.season" @change="fetchSchedule()"
+                                class="w-full bg-gray-800 border border-gray-700 rounded p-1.5 md:p-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-red-600">
+                            <option value="">Select Season</option>
+                            <template x-for="s in seasons" :key="s.season">
+                                <option :value="s.season" x-text="s.season"></option>
+                            </template>
+                        </select>
                     </div>
                     <div>
                         <label for="input-round" class="block text-xs font-bold text-gray-400 mb-1 uppercase tracking-wider">Round</label>
-                        <input id="input-round" type="text" x-model="params.round" placeholder="next"
-                               class="w-full bg-gray-800 border border-gray-700 rounded p-1.5 md:p-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-red-600">
+                        <select id="input-round" x-model="params.round" :disabled="!params.season || scheduleLoading"
+                                class="w-full bg-gray-800 border border-gray-700 rounded p-1.5 md:p-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-red-600 disabled:opacity-50">
+                            <option value="">Select Round</option>
+                            <template x-for="r in schedule" :key="r.round">
+                                <option :value="r.round" x-text="'Round ' + r.round + ': ' + r.raceName"></option>
+                            </template>
+                        </select>
                     </div>
                     <div class="col-span-2 md:col-span-1">
                         <label class="block text-xs font-bold text-gray-400 mb-1 uppercase tracking-wider" id="sessions-label">Sessions</label>
@@ -294,7 +304,10 @@
         function f1App() {
             return {
                 loading: false,
+                scheduleLoading: false,
                 config: {},
+                seasons: [],
+                schedule: [],
                 params: {
                     season: '',
                     round: '',
@@ -308,11 +321,45 @@
 
                 async init() {
                     try {
-                        const resp = await fetch('/api/config');
-                        this.config = await resp.json();
+                        // Load Config
+                        const configResp = await fetch('/api/config');
+                        this.config = await configResp.json();
                         this.params.sessions = this.config.default_sessions || ['qualifying', 'race'];
+
+                        // Load Seasons
+                        const seasonsResp = await fetch('/api/seasons');
+                        this.seasons = await seasonsResp.json();
+
+                        // Pre-select if available
+                        if (this.config.next_event) {
+                            this.params.season = this.config.next_event.season || '';
+                            await this.fetchSchedule();
+                            this.params.round = this.config.next_event.round || '';
+                        }
                     } catch (e) {
-                        console.error("Failed to load config", e);
+                        console.error("Failed to initialize app", e);
+                        this.error = "Failed to initialize application data. Check your connection.";
+                    }
+                },
+
+                async fetchSchedule() {
+                    if (!this.params.season) {
+                        this.schedule = [];
+                        return;
+                    }
+                    this.scheduleLoading = true;
+                    try {
+                        const resp = await fetch(`/api/schedule/${this.params.season}`);
+                        const data = await resp.json();
+                        this.schedule = data.races || [];
+                        // Reset round if current round is not in new schedule
+                        if (!this.schedule.some(r => r.round == this.params.round)) {
+                            this.params.round = '';
+                        }
+                    } catch (e) {
+                        console.error("Failed to fetch schedule", e);
+                    } finally {
+                        this.scheduleLoading = false;
                     }
                 },
 

--- a/f1pred/web.py
+++ b/f1pred/web.py
@@ -71,11 +71,35 @@ async def index(request: Request):
 async def get_web_config():
     if not _config:
         return {"error": "Config not initialized"}
+
+    # Get next round info for pre-selection
+    jc = JolpicaClient(_config.data_sources.jolpica.base_url)
+    try:
+        next_s, next_r = jc.get_next_round()
+    except Exception:
+        next_s, next_r = None, None
+
     return {
         "model_version": _config.app.model_version,
         "app_version": __version__,
-        "default_sessions": _config.modelling.targets.session_types
+        "default_sessions": _config.modelling.targets.session_types,
+        "next_event": {
+            "season": next_s,
+            "round": next_r
+        }
     }
+
+@app.get("/api/seasons")
+async def get_seasons():
+    jc = JolpicaClient(_config.data_sources.jolpica.base_url)
+    try:
+        seasons = jc.get_seasons()
+        # Return in descending order for better UX (newest first)
+        seasons.sort(key=lambda x: x.get("season", "0"), reverse=True)
+        return seasons
+    except Exception as e:
+        logger.exception("Failed to get seasons")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 @app.get("/api/schedule/{season}")
 async def get_schedule(season: str):


### PR DESCRIPTION
This PR improves the user experience by replacing the freeform text inputs for season and round with dynamic dropdown menus.

Key changes:
- **Backend:** Added `get_seasons()` to `JolpicaClient` and a corresponding `/api/seasons` endpoint. Updated `/api/config` to provide the upcoming event's season and round number.
- **Frontend:** Updated `index.html` (Alpine.js) to fetch available seasons and rounds. The Round dropdown is now context-aware, updating its options (including race names) based on the selected season. The upcoming event is automatically pre-selected on initialization.

These changes ensure that users can only select valid canonical data and provide better context by showing the names of the races.

Fixes #185

---
*PR created automatically by Jules for task [4401777311350006139](https://jules.google.com/task/4401777311350006139) started by @2fst4u*