### PR TITLE
WebUI Usability Improvement: Results Bypass and Session Indicators

### DIFF
--- a/f1pred/predict.py
+++ b/f1pred/predict.py
@@ -174,11 +174,17 @@ def _get_actual_positions_for_session(
         return None
 
 
-def _filter_sessions_for_round(jc: JolpicaClient, season_i: int, round_i: int, requested: List[str]) -> List[str]:
-    """Assume a regular weekend unless confirmed otherwise.
+def _filter_sessions_for_round(
+    jc: JolpicaClient,
+    season_i: int,
+    round_i: int,
+    requested: List[str],
+    race_info: Optional[Dict[str, Any]] = None
+) -> List[str]:
+    """Ensure requested sessions are valid for the round.
 
     - Always keep qualifying and race.
-    - Include sprint and sprint_qualifying only if the current round already has sprint results posted.
+    - Include sprint and sprint_qualifying if they are in race_info.
     """
     keep = []
     requested_norm = [s.strip().lower() for s in requested]
@@ -187,15 +193,19 @@ def _filter_sessions_for_round(jc: JolpicaClient, season_i: int, round_i: int, r
         if s in requested_norm:
             keep.append(s)
 
-    try:
-        has_sprint = bool(jc.get_sprint_results(str(season_i), str(round_i)))
-    except Exception:
-        has_sprint = False
+    # Use provided race_info or fetch it
+    if race_info is None:
+        try:
+            race_info = jc.get_event(str(season_i), str(round_i))
+        except Exception:
+            race_info = {}
 
-    if has_sprint:
-        for s in ("sprint_qualifying", "sprint"):
-            if s in requested_norm:
-                keep.append(s)
+    if "Sprint" in race_info:
+        if "sprint" in requested_norm:
+            keep.append("sprint")
+    if "SprintQualifying" in race_info:
+        if "sprint_qualifying" in requested_norm:
+            keep.append("sprint_qualifying")
 
     return keep
 
@@ -456,7 +466,7 @@ def run_predictions_for_event(
         event_date = datetime.now(timezone.utc)
 
     # Filter requested sessions for this round
-    sessions = _filter_sessions_for_round(jc, season_i, round_i, sessions)
+    sessions = _filter_sessions_for_round(jc, season_i, round_i, sessions, race_info=race_info)
     
     # Sort sessions chronologically to ensure history flows correctly
     # Standard order: Practice -> Sprint Shootout -> Sprint -> Qualifying -> Race
@@ -527,17 +537,60 @@ def run_predictions_for_event(
                     logger.info(f"[predict] {msg}")
                     continue
 
-                # Cache check
-                cache_inputs = {
+                # 1. Check for actual results first (Bypass prediction if results exist)
+                actual_positions = _get_actual_positions_for_session(
+                    jc,
+                    season_i,
+                    round_i,
+                    sess,
+                    roster[["driverId", "number", "code"]] if "number" in roster.columns else roster[["driverId"]]
+                )
+
+                if actual_positions is not None and not actual_positions.isna().all():
+                    spinner.update(f"Using actual results for {sess}...")
+                    logger.info(f"[predict] Using actual results for {season_i} R{round_i} {sess}")
+
+                    ranked = X.copy()
+                    # Ensure columns for actuals mapping exist
+                    if "number" not in ranked.columns:
+                        ranked["number"] = roster["number"] if "number" in roster.columns else pd.NA
+                    if "code" not in ranked.columns:
+                        ranked["code"] = roster["code"] if "code" in roster.columns else ""
+
+                    ranked["actual_position"] = actual_positions
+                    # Sort by actual position
+                    ranked = ranked.sort_values("actual_position").reset_index(drop=True)
+
+                    # Fill in prediction-like columns for UI consistency
+                    ranked["predicted_position"] = ranked["actual_position"]
+                    ranked["mean_pos"] = ranked["actual_position"].astype(float)
+                    ranked["p_win"] = (ranked["actual_position"] == 1).astype(float)
+                    ranked["p_top3"] = (ranked["actual_position"] <= 3).astype(float)
+                    ranked["p_dnf"] = ranked["actual_position"].isna().astype(float)
+                    ranked["delta"] = 0
+
+                    # Mock prob_matrix and pairwise for consistency
+                    prob_matrix = np.zeros((len(ranked), len(ranked)))
+                    for i in range(len(ranked)):
+                        val = ranked.loc[i, "actual_position"]
+                        if pd.notna(val):
+                            pos = int(val)
+                            if 1 <= pos <= len(ranked):
+                                prob_matrix[i, pos-1] = 1.0
+                    pairwise = None
+
+                    p_top3 = ranked["p_top3"].values
+                    p_win = ranked["p_win"].values
+                    dnf_prob = ranked["p_dnf"].values
+
+                # 2. Cache check (if no actual results)
+                elif (cached_hit := pred_cache.get(cache_inputs := {
                     "X": X,
                     "weather": meta.get("weather"),
                     "model_version": cfg.app.model_version,
                     "weights": calibrated_weights,
                     "modelling_cfg": cfg.modelling,
-                }
-                cached_hit = pred_cache.get(cache_inputs)
-
-                if cached_hit:
+                })):
                     spinner.update(f"Predicting {event_title} - {sess}: Using cached result...")
                     ranked = cached_hit["ranked"]
                     prob_matrix = cached_hit["prob_matrix"]

--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -67,7 +67,7 @@
                     </div>
                     <div>
                         <label for="input-round" class="block text-xs font-bold text-gray-400 mb-1 uppercase tracking-wider">Round</label>
-                        <select id="input-round" x-model="params.round" :disabled="!params.season || scheduleLoading"
+                        <select id="input-round" x-model="params.round" @change="fetchEventStatus()" :disabled="!params.season || scheduleLoading"
                                 class="w-full bg-gray-800 border border-gray-700 rounded p-1.5 md:p-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-red-600 disabled:opacity-50">
                             <option value="">Select Round</option>
                             <template x-for="r in schedule" :key="r.round">
@@ -78,13 +78,19 @@
                     <div class="col-span-2 md:col-span-1">
                         <label class="block text-xs font-bold text-gray-400 mb-1 uppercase tracking-wider" id="sessions-label">Sessions</label>
                         <div class="flex flex-wrap gap-2 mt-1" role="group" aria-labelledby="sessions-label">
-                            <template x-for="s in ['qualifying', 'race', 'sprint', 'sprint_qualifying']">
-                                <button @click="toggleSession(s)"
-                                        :aria-pressed="params.sessions.includes(s)"
-                                        :class="params.sessions.includes(s) ? 'bg-red-600 text-white' : 'bg-gray-800 text-gray-400'"
-                                        class="text-xs px-2 py-1 rounded border border-gray-700 hover:border-red-500 transition focus:outline-none focus:ring-2 focus:ring-red-500"
-                                        x-text="s.replace('_', ' ').toUpperCase()">
+                            <template x-for="s in eventSessions" :key="s.id">
+                                <button @click="toggleSession(s.id)"
+                                        :aria-pressed="params.sessions.includes(s.id)"
+                                        :class="params.sessions.includes(s.id) ? 'bg-red-600 text-white' : 'bg-gray-800 text-gray-400'"
+                                        class="text-[10px] md:text-xs px-2 py-1 rounded border border-gray-700 hover:border-red-500 transition focus:outline-none focus:ring-2 focus:ring-red-500 flex items-center space-x-1">
+                                    <span x-text="s.id.replace('_', ' ').toUpperCase()"></span>
+                                    <template x-if="s.has_results">
+                                        <i class="fas fa-check-circle text-green-400 ml-1" title="Results available"></i>
+                                    </template>
                                 </button>
+                            </template>
+                            <template x-if="!eventSessions.length">
+                                <span class="text-xs text-gray-500 italic">Select a round...</span>
                             </template>
                         </div>
                     </div>
@@ -308,6 +314,8 @@
                 config: {},
                 seasons: [],
                 schedule: [],
+                eventSessions: [],
+                statusLoading: false,
                 params: {
                     season: '',
                     round: '',
@@ -335,6 +343,7 @@
                             this.params.season = this.config.next_event.season || '';
                             await this.fetchSchedule();
                             this.params.round = this.config.next_event.round || '';
+                            await this.fetchEventStatus();
                         }
                     } catch (e) {
                         console.error("Failed to initialize app", e);
@@ -355,11 +364,43 @@
                         // Reset round if current round is not in new schedule
                         if (!this.schedule.some(r => r.round == this.params.round)) {
                             this.params.round = '';
+                            this.eventSessions = [];
+                        } else {
+                             await this.fetchEventStatus();
                         }
                     } catch (e) {
                         console.error("Failed to fetch schedule", e);
                     } finally {
                         this.scheduleLoading = false;
+                    }
+                },
+
+                async fetchEventStatus() {
+                    if (!this.params.season || !this.params.round) {
+                        this.eventSessions = [];
+                        return;
+                    }
+                    this.statusLoading = true;
+                    try {
+                        const resp = await fetch(`/api/event-status/${this.params.season}/${this.params.round}`);
+                        const data = await resp.json();
+                        this.eventSessions = data.sessions || [];
+
+                        // Auto-select sessions that don't have results yet
+                        const toSelect = this.eventSessions
+                            .filter(s => !s.has_results)
+                            .map(s => s.id);
+
+                        if (toSelect.length > 0) {
+                            this.params.sessions = toSelect;
+                        } else if (this.eventSessions.length > 0) {
+                            // If all have results, just select the main ones or none
+                            this.params.sessions = [this.eventSessions[this.eventSessions.length - 1].id];
+                        }
+                    } catch (e) {
+                        console.error("Failed to fetch event status", e);
+                    } finally {
+                        this.statusLoading = false;
                     }
                 },
 

--- a/f1pred/web.py
+++ b/f1pred/web.py
@@ -111,6 +111,75 @@ async def get_schedule(season: str):
         logger.exception("Failed to get schedule")
         raise HTTPException(status_code=500, detail="Internal server error")
 
+@app.get("/api/event-status/{season}/{round}")
+async def get_event_status(season: str, round: str):
+    if not _config:
+        raise HTTPException(status_code=500, detail="Application not configured")
+
+    jc = JolpicaClient(
+        _config.data_sources.jolpica.base_url,
+        _config.data_sources.jolpica.timeout_seconds,
+        _config.data_sources.jolpica.rate_limit_sleep,
+    )
+
+    try:
+        # Resolve actual season/round numbers
+        s_i, r_i, race_info = resolve_event(jc, season, round)
+
+        # Standard chronological order
+        all_possible = ["sprint_qualifying", "sprint", "qualifying", "race"]
+        sessions = []
+
+        # Check for each session if it exists in race_info and if results exist
+        for s in all_possible:
+            # Race and Qualifying always exist in F1
+            exists = s in ("race", "qualifying")
+
+            # Sprint sessions only if present in race_info
+            if s == "sprint" and "Sprint" in race_info:
+                exists = True
+            if s == "sprint_qualifying" and "SprintQualifying" in race_info:
+                exists = True
+
+            if exists:
+                has_results = False
+                try:
+                    if s == "race":
+                        has_results = bool(jc.get_race_results(str(s_i), str(r_i)))
+                    elif s == "qualifying":
+                        has_results = bool(jc.get_qualifying_results(str(s_i), str(r_i)))
+                    elif s == "sprint":
+                        has_results = bool(jc.get_sprint_results(str(s_i), str(r_i)))
+                    elif s == "sprint_qualifying":
+                        # Sprint shootout results can be in Jolpica as 'sprintQualifying' sometimes
+                        # but standard Ergast API doesn't have it.
+                        # However, some Jolpica extensions might.
+                        # We check if _get_actual_positions_for_session can find it.
+                        from .predict import _get_actual_positions_for_session
+                        from .roster import get_roster
+                        roster = get_roster(jc, str(s_i), str(r_i))
+                        if roster is not None:
+                             acts = _get_actual_positions_for_session(jc, s_i, r_i, s, roster)
+                             has_results = acts is not None and not acts.isna().all()
+                except Exception:
+                    has_results = False
+
+                sessions.append({
+                    "id": s,
+                    "name": s.replace("_", " ").title(),
+                    "has_results": has_results
+                })
+
+        return {
+            "season": s_i,
+            "round": r_i,
+            "raceName": race_info.get("raceName"),
+            "sessions": sessions
+        }
+    except Exception as e:
+        logger.exception("Failed to get event status")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
 @app.get("/api/predict")
 async def get_predictions(
     season: Optional[str] = None,


### PR DESCRIPTION
This change improves the WebUI usability by ensuring that predictions are only run for sessions where real results don't exist yet. For past sessions, it directly returns the actual results. It also adds visual indicators to the session selection buttons to show which results are ready, and ensures sessions are ordered chronologically and correctly filtered based on the round's format (Sprint vs Standard).

Fixes #188

---
*PR created automatically by Jules for task [933314154248375018](https://jules.google.com/task/933314154248375018) started by @2fst4u*