### PR TITLE
🎨 Palette: Add loading indicators to data-fetching inputs

### DIFF
--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -59,7 +59,7 @@
                         <label for="input-season" class="block text-xs font-bold text-gray-400 mb-1 uppercase tracking-wider">Season</label>
                         <select id="input-season" x-model="params.season" @change="fetchSchedule()"
                                 class="w-full bg-gray-800 border border-gray-700 rounded p-1.5 md:p-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-red-600">
-                            <option value="">Select Season</option>
+                            <option value="" x-text="seasons.length ? 'Select Season' : 'Loading seasons...'"></option>
                             <template x-for="s in seasons" :key="s.season">
                                 <option :value="s.season" x-text="s.season"></option>
                             </template>
@@ -69,7 +69,7 @@
                         <label for="input-round" class="block text-xs font-bold text-gray-400 mb-1 uppercase tracking-wider">Round</label>
                         <select id="input-round" x-model="params.round" @change="fetchEventStatus()" :disabled="!params.season || scheduleLoading"
                                 class="w-full bg-gray-800 border border-gray-700 rounded p-1.5 md:p-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-red-600 disabled:opacity-50">
-                            <option value="">Select Round</option>
+                            <option value="" x-text="scheduleLoading ? 'Loading rounds...' : 'Select Round'"></option>
                             <template x-for="r in schedule" :key="r.round">
                                 <option :value="r.round" x-text="'Round ' + r.round + ': ' + r.raceName"></option>
                             </template>
@@ -89,8 +89,13 @@
                                     </template>
                                 </button>
                             </template>
-                            <template x-if="!eventSessions.length">
-                                <span class="text-xs text-gray-500 italic">Select a round...</span>
+                            <template x-if="statusLoading">
+                                <span class="text-[10px] md:text-xs px-2 py-1 text-gray-400 italic flex items-center">
+                                    <i class="fas fa-circle-notch fa-spin mr-1.5" aria-hidden="true"></i> Loading...
+                                </span>
+                            </template>
+                            <template x-if="!eventSessions.length && !statusLoading">
+                                <span class="text-xs text-gray-500 italic mt-1.5">Select a round...</span>
                             </template>
                         </div>
                     </div>


### PR DESCRIPTION
💡 **What**: Added loading states to the dynamic inputs in the F1 Predictor UI. The "Season" and "Round" dropdowns now display a loading message while their data is being fetched. The "Sessions" toggle area now displays a spinning loader while session status is resolving.

🎯 **Why**: When a user first opens the page or changes the season, the app asynchronously fetches data from the backend. Previously, the UI gave no indication that data was loading, which could lead to confusion or the impression that the app was unresponsive. Providing immediate visual feedback creates a smoother, more trustworthy experience.

📸 **Before/After**: The "Round" dropdown now says "Loading rounds..." instead of just sitting empty or showing "Select Round", and a spinner appears above it.

♿ **Accessibility**: Used semantic FontAwesome icons with `aria-hidden="true"` to ensure screen readers don't read out the visual-only spinning icon, while the text clearly communicates the "Loading" state. The change stays under 50 lines and leverages existing Alpine.js and Tailwind architecture.

---
*PR created automatically by Jules for task [12892979730897635960](https://jules.google.com/task/12892979730897635960) started by @2fst4u*