### PR TITLE
Clear UI indicators when switching rounds

### DIFF
--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -379,8 +379,9 @@
                 },
 
                 async fetchEventStatus() {
+                    this.eventSessions = [];
+                    this.results = null;
                     if (!this.params.season || !this.params.round) {
-                        this.eventSessions = [];
                         return;
                     }
                     this.statusLoading = true;


### PR DESCRIPTION
The "actual results" indicators (green ticks) in the Web UI were persisting when a user switched from a completed round to a future round, because the session list was only updated after the status API call returned.

I modified `f1pred/templates/index.html` to clear `eventSessions` and `results` at the beginning of the `fetchEventStatus` function. This ensures the UI state is reset immediately when the user changes the round selection, providing better visual feedback that a new configuration is being loaded.

Verification:
1. Created a Playwright script that simulated a 5-second delay for the `/api/event-status` endpoint.
2. Verified that before the fix, the ticks remained visible during those 5 seconds.
3. Verified that after the fix, the ticks and session buttons disappear immediately upon changing the round.
4. Ran `python -m pytest` to ensure no regressions in the core prediction logic or web routes.

Fixes #210

---
*PR created automatically by Jules for task [10583264393014730246](https://jules.google.com/task/10583264393014730246) started by @2fst4u*