### PR TITLE
🧪 Spec: Add test for init_caches disable flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,5 +38,5 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 49.88
+fail_under = 49.91
 show_missing = true

--- a/tests/test_util_core.py
+++ b/tests/test_util_core.py
@@ -42,3 +42,19 @@ def test_session_with_retries():
     assert adapter.max_retries.total == 2
     assert adapter.max_retries.connect == 1
     assert adapter.max_retries.read == 1
+
+def test_init_caches_disabled():
+    # Arrange
+    from f1pred.util import init_caches
+    class MockConfig:
+        pass
+    cfg = MockConfig()
+
+    # Act
+    # Calling init_caches with disable_cache=True should return immediately.
+    # We verify it doesn't raise any errors or try to access missing config attributes.
+    init_caches(cfg, disable_cache=True)
+
+    # Assert
+    # If no exception is raised, the test passes and coverage is achieved for lines 133-134.
+    assert True


### PR DESCRIPTION
💡 **What:** Added a new unit test `test_init_caches_disabled` to `tests/test_util_core.py`.
🎯 **Why:** To test the early return functionality in `f1pred.util.init_caches` when `disable_cache=True` is provided, achieving missing coverage for lines 133-134 in `f1pred/util.py`.
📈 **Ratchet:** Increased statement coverage threshold by 0.03% to lock in the gain from this new test.

---
*PR created automatically by Jules for task [15291986536316118675](https://jules.google.com/task/15291986536316118675) started by @2fst4u*