### PR TITLE
🎨 Palette: Distinct Gold/Silver/Bronze colors for top 3 positions

### DIFF
--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -226,7 +226,7 @@
                                         <template x-for="(p, index) in data.predictions" :key="p.driverId">
                                             <tr class="hover:bg-gray-800 transition group text-sm sm:text-base" :class="getTeamClass(p.constructorName)">
                                                 <td class="px-0.5 py-2 sm:p-4 text-center font-black italic text-base sm:text-lg"
-                                                    :class="index < 3 ? 'text-yellow-500' : 'text-gray-500'"
+                                                    :class="index === 0 ? 'text-yellow-400' : index === 1 ? 'text-gray-300' : index === 2 ? 'text-amber-600' : 'text-gray-500'"
                                                     x-text="p.predicted_position"></td>
                                                 <td class="px-0.5 py-2 sm:p-4">
                                                     <div class="flex items-center space-x-1 sm:space-x-3">

--- a/test_ui.sh
+++ b/test_ui.sh
@@ -1,0 +1,5 @@
+python main.py --web --port 8000 &
+PID=$!
+sleep 2
+curl -s http://localhost:8000 | grep -q "F1 OUTCOME PREDICTOR" && echo "UI loaded successfully"
+kill $PID


### PR DESCRIPTION
💡 What: Updated the Web UI predictions table to use distinct Tailwind colors (Gold: `text-yellow-400`, Silver: `text-gray-300`, Bronze: `text-amber-600`) for the top 3 positions, replacing the previous uniform yellow highlight.
🎯 Why: To align the Web UI with the visual hierarchy pattern already established in the CLI, allowing users to scan the leaderboard and identify podium positions (1st, 2nd, 3rd) immediately without needing to read the numbers.
📸 Before/After: Visualized via Playwright testing and verified.
♿ Accessibility: No negative impact on contrast ratios; the colors are easily distinguishable from the dark background.

---
*PR created automatically by Jules for task [10772310519735946562](https://jules.google.com/task/10772310519735946562) started by @2fst4u*