### PR TITLE
📚 Archivist: Update FastF1 documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The app fetches data from free, public APIs:
 - **[Jolpica F1](https://github.com/jolpica/jolpica-f1)** – Schedules, results, standings (Ergast-compatible)
 - **[Open-Meteo](https://open-meteo.com/)** – Weather forecasts and historical weather
 
-- **[FastF1](https://theoehrly.github.io/Fast-F1/)** – Detailed timing and telemetry fallback
+- **[FastF1](https://docs.fastf1.dev/)** – Detailed timing and telemetry fallback
 
 ## How It Works
 


### PR DESCRIPTION
💡 Problem: The `README.md` linked to an outdated GitHub Pages site (`https://theoehrly.github.io/Fast-F1/`) for FastF1 documentation, which triggers an HTTP 301 redirect.
🎯 Fix: Updated the FastF1 link to the current, canonical domain: `https://docs.fastf1.dev/`.
🧪 Verification: Checked the redirect path via curl to confirm the new domain, ran `make test` locally to ensure no regressions, and ran `prettier --write` to ensure formatting compliance.
🔎 Scope: Confirmation that this PR contains ONLY documentation changes in `README.md`.

---
*PR created automatically by Jules for task [2381128151990204498](https://jules.google.com/task/2381128151990204498) started by @2fst4u*