### PR TITLE
🧪 Spec: Add config validation test and bump coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,5 +38,5 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 49.91
+fail_under = 49.96
 show_missing = true

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -307,3 +307,15 @@ def test_load_config_invalid_config_file_returns_errors(full_valid_config):
         assert "modelling.monte_carlo.draws must be between 100" in err_msg
     finally:
         os.remove(path)
+
+def test_load_config_missing_monte_carlo(full_valid_config):
+    """Verify missing monte_carlo section is caught."""
+    del full_valid_config["modelling"]["monte_carlo"]
+    path = _write_config(full_valid_config)
+    try:
+        with pytest.raises(ValueError) as excinfo:
+            load_config(path)
+        err_msg = str(excinfo.value)
+        assert "Missing required key 'modelling.monte_carlo'" in err_msg
+    finally:
+        os.remove(path)


### PR DESCRIPTION
💡 **What:** Added a new unit test `test_load_config_missing_monte_carlo` to `tests/test_config.py` to cover the final missing lines in `f1pred/config.py`. 
🎯 **Why:** `f1pred/config.py` lacked coverage for a specific nested config dictionary validation check where `modelling.monte_carlo` is missing from the configuration file. Adding this test brings the module to 100% coverage.
📈 **Ratchet:** Increased statement coverage threshold by 0.05% (from `49.91` to `49.96`) to lock in the gain from this new test.

---
*PR created automatically by Jules for task [2896437620545565](https://jules.google.com/task/2896437620545565) started by @2fst4u*