### PR TITLE
🎨 Palette: [UI State Affordance & Error Dismissal UX Improvements]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -49,3 +49,11 @@
 ## 2025-05-24 - Alpine.js Custom Toggle Accessibility
 **Learning:** When using custom `<button>` elements in Alpine.js (`x-data`) to act as toggleable options (like multi-select checkboxes), screen readers will not announce their state changes unless explicitly provided.
 **Action:** Always add `:aria-pressed="condition.toString()"` to Alpine.js buttons that function as state toggles, ensuring screen reader users can perceive their current selected state.
+
+## 2026-05-24 - Disabled Affordances and Explanation
+**Learning:** Users often get frustrated when a primary action button is simply grayed out with no explanation as to why. While visual indicators like `disabled:opacity-50` and `cursor-not-allowed` are necessary, explicitly telling the user what's missing (e.g., via a dynamic `title` attribute or a tooltip) drastically improves the perceived accessibility and intuitiveness of the form.
+**Action:** When disabling form submit buttons due to missing prerequisites, always provide a contextual string indicating what the user still needs to fill out (e.g. "Select a season and round to predict").
+
+## 2026-05-24 - Ephemeral Error State UX
+**Learning:** Persistent error banners that don't offer a way to be dismissed can obscure content and leave users feeling trapped in an error state. Even if an error is temporary, providing a manual escape hatch (like an accessible "X" button) improves user autonomy.
+**Action:** Always provide an explicit dismiss/close action for error alerts or toast notifications using standard recognizable icons (`fa-times`) and focusable button elements.

--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -68,7 +68,7 @@
                     <div>
                         <label for="input-round" class="block text-xs font-bold text-gray-400 mb-1 uppercase tracking-wider">Round</label>
                         <select id="input-round" x-model="params.round" @change="fetchEventStatus()" :disabled="!params.season || scheduleLoading"
-                                class="w-full bg-gray-800 border border-gray-700 rounded p-1.5 md:p-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-red-600 disabled:opacity-50">
+                                class="w-full bg-gray-800 border border-gray-700 rounded p-1.5 md:p-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-red-600 disabled:opacity-50 disabled:cursor-not-allowed">
                             <option value="" x-text="scheduleLoading ? 'Loading rounds...' : 'Select Round'"></option>
                             <template x-for="r in schedule" :key="r.round">
                                 <option :value="r.round" x-text="'Round ' + r.round + ': ' + r.raceName"></option>
@@ -100,8 +100,9 @@
                         </div>
                     </div>
                     <div class="col-span-2 md:col-span-1">
-                        <button @click="runPrediction()" :disabled="loading"
-                                class="w-full f1-red hover:bg-red-700 text-white font-bold py-2 px-4 rounded shadow-lg disabled:opacity-50 transition transform active:scale-95 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-900">
+                        <button @click="runPrediction()" :disabled="loading || !params.season || !params.round || params.sessions.length === 0"
+                                :title="(!params.season || !params.round) ? 'Select a season and round to predict' : (params.sessions.length === 0 ? 'Select at least one session' : '')"
+                                class="w-full f1-red hover:bg-red-700 text-white font-bold py-2 px-4 rounded shadow-lg disabled:opacity-50 disabled:cursor-not-allowed transition transform active:scale-95 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-900">
                             <span x-show="!loading">RUN PREDICTION</span>
                             <span x-show="loading" class="flex items-center justify-center">
                                 <i class="fas fa-spinner animate-spin mr-2"></i> PROCESSING...
@@ -113,8 +114,15 @@
 
             <!-- Error Message -->
             <div x-show="error" x-transition x-cloak class="bg-red-900 border-l-4 border-red-500 text-red-100 p-4 mb-8" role="alert">
-                <p class="font-bold">Error</p>
-                <p x-text="error"></p>
+                <div class="flex justify-between items-start">
+                    <div>
+                        <p class="font-bold">Error</p>
+                        <p x-text="error"></p>
+                    </div>
+                    <button @click="error = null" aria-label="Dismiss error" title="Dismiss error" class="text-red-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-white rounded p-1 transition">
+                        <i class="fas fa-times"></i>
+                    </button>
+                </div>
             </div>
 
             <!-- Progress Logs -->


### PR DESCRIPTION
💡 What: Added an accessible dismiss ('X') button to the error alert and disabled the 'RUN PREDICTION' button when prerequisites (season, round, sessions) are missing, including a contextual tooltip.
🎯 Why: Users were frustrated when actions were grayed out without explanation, and persistent error banners obscured content without a way to dismiss them. These changes improve user autonomy and provide clear feedback.
♿ Accessibility: The dismiss button includes `aria-label`, `title`, and focus states. The disabled button provides an explicit tooltip explaining the missing prerequisites.

---
*PR created automatically by Jules for task [8534769534974929838](https://jules.google.com/task/8534769534974929838) started by @2fst4u*