### PR TITLE
🧪 Spec: Add PredictionCache test coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,5 +38,5 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 49.96
+fail_under = 50.18
 show_missing = true

--- a/tests/test_util_cache.py
+++ b/tests/test_util_cache.py
@@ -1,7 +1,14 @@
-from f1pred.util import PredictionCache
 import os
+import logging
+from datetime import datetime
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import pytest
 import numpy as np
 import pandas as pd
+
+from f1pred.util import PredictionCache
 
 def test_cache_rolling_deletion(tmp_path):
     # Set up cache with max_entries = 2
@@ -46,3 +53,77 @@ def test_cache_get_miss(tmp_path):
     inputs = {"test": "miss"}
     data = cache.get(inputs)
     assert data is None
+
+@dataclass
+class DummyDataclass:
+    a: int
+    b: str
+
+def test_cache_extended_serialization(tmp_path):
+    cache = PredictionCache(cache_dir=str(tmp_path), max_entries=2)
+    dt = datetime(2023, 1, 1, 12, 0)
+    ts = pd.Timestamp("2024-01-01")
+    dc = DummyDataclass(a=1, b="test")
+
+    inputs = {
+        "dt": dt,
+        "ts": ts,
+        "dc": dc,
+        "lst": [1, 2, dt]
+    }
+    results = {"val": 42}
+
+    cache.set(inputs, results)
+    data = cache.get(inputs)
+    assert data is not None
+    assert data["val"] == 42
+
+def test_cache_get_error_handling(tmp_path, caplog):
+    cache = PredictionCache(cache_dir=str(tmp_path), max_entries=2)
+    inputs = {"test": 1}
+    results = {"val": 42}
+    cache.set(inputs, results)
+
+    key = cache._generate_key(inputs)
+    cache_file = cache.cache_dir / f"{key}.json"
+
+    # Corrupt the JSON file to trigger Exception during load
+    with open(cache_file, "w") as f:
+        f.write("{invalid_json:")
+
+    with caplog.at_level(logging.WARNING):
+        data = cache.get(inputs)
+
+    assert data is None
+    assert "Failed to load prediction cache" in caplog.text
+
+def test_cache_set_error_handling(tmp_path, caplog):
+    cache = PredictionCache(cache_dir=str(tmp_path), max_entries=2)
+
+    # Make cache directory read-only to trigger exception during set
+    os.chmod(cache.cache_dir, 0o444)
+
+    inputs = {"test": 2}
+    results = {"val": 42}
+
+    try:
+        with caplog.at_level(logging.WARNING):
+            cache.set(inputs, results)
+        assert "Failed to save prediction cache" in caplog.text
+    finally:
+        os.chmod(cache.cache_dir, 0o755) # Restore permissions
+
+def test_cache_rolling_deletion_unlink_fails(tmp_path):
+    cache = PredictionCache(cache_dir=str(tmp_path), max_entries=2)
+    for i in range(2):
+        cache.set({"k": i}, {"v": i})
+
+    # Cause unlink to raise an exception by mocking pathlib.Path.unlink
+    with patch("pathlib.Path.unlink") as mock_unlink:
+        mock_unlink.side_effect = OSError("Mock unlink error")
+
+        # Trigger deletion
+        cache.set({"k": 3}, {"v": 3})
+
+    # Assert that exception was caught and ignored (files won't actually be deleted)
+    assert len(list(cache.cache_dir.glob("*.json"))) == 3


### PR DESCRIPTION
💡 What: Added unit tests targeting untested error conditions and object serialization in `f1pred.util.PredictionCache`. Reorganized imports in `tests/test_util_cache.py` to be clean and conform to PEP-8.
🎯 Why: `PredictionCache` interacts with the filesystem, making it a critical path for the F1 predictions. Its error handling logic and comprehensive type-serialization were largely uncovered.
📈 Ratchet: Increased statement coverage threshold by 0.22% (49.96% -> 50.18%) to lock in the gain from these new tests.

---
*PR created automatically by Jules for task [212745482626842130](https://jules.google.com/task/212745482626842130) started by @2fst4u*