### PR TITLE
Fix default round selection logic

### DIFF
--- a/f1pred/predict.py
+++ b/f1pred/predict.py
@@ -32,7 +32,27 @@ def resolve_event(jc: JolpicaClient, season: Optional[str], rnd: str) -> Tuple[i
     try:
         if season is None or (isinstance(season, str) and season.lower() == "current"):
             if rnd == "next":
-                s, r = jc.get_next_round()
+                try:
+                    s, r = jc.get_next_round()
+                    # Verify if this round is actually in the future or very recent
+                    # Jolpica's "next" pointer sometimes lags behind after a race.
+                    races = jc.get_season_schedule(str(s))
+                    this_race = next((x for x in races if str(x.get("round")) == str(r)), None)
+                    if this_race:
+                        race_dt = datetime.fromisoformat(this_race["date"] + "T00:00:00+00:00")
+                        now = datetime.now(timezone.utc)
+                        # If the race was more than 1 day ago, it's likely stale
+                        if race_dt < now - timedelta(days=1):
+                            future = [x for x in races if datetime.fromisoformat(x["date"] + "T00:00:00+00:00") >= now - timedelta(days=1)]
+                            if future:
+                                r = future[0]["round"]
+                except Exception:
+                    # Fallback to schedule scan
+                    s, _ = jc.get_latest_season_and_round()
+                    races = jc.get_season_schedule(str(s))
+                    now = datetime.now(timezone.utc)
+                    future = [x for x in races if datetime.fromisoformat(x["date"] + "T00:00:00+00:00") >= now - timedelta(days=1)]
+                    r = future[0]["round"] if future else races[-1]["round"]
             elif rnd == "last":
                 s, r = jc.get_latest_season_and_round()
             else:

--- a/f1pred/util.py
+++ b/f1pred/util.py
@@ -156,7 +156,11 @@ def init_caches(cfg, disable_cache: bool = False) -> None:
 
     # Jolpica
     if getattr(ds.jolpica, "base_url", None):
-        urls_expire_after[ds.jolpica.base_url] = default_expire_seconds
+        base_url = ds.jolpica.base_url.rstrip("/")
+        urls_expire_after[base_url] = default_expire_seconds
+        # Shorten TTL for dynamic "next" and "last" pointers
+        urls_expire_after[f"{base_url}/current/next.json"] = forecast_expire_seconds
+        urls_expire_after[f"{base_url}/current/last.json"] = forecast_expire_seconds
 
     backend = cfg.caching.requests_cache.backend
     cache_path = Path(cfg.paths.cache_dir) / "http_cache"

--- a/f1pred/web.py
+++ b/f1pred/web.py
@@ -74,7 +74,7 @@ async def get_web_config():
     # Get next round info for pre-selection
     jc = JolpicaClient(_config.data_sources.jolpica.base_url)
     try:
-        next_s, next_r = jc.get_next_round()
+        next_s, next_r, _ = resolve_event(jc, "current", "next")
     except Exception:
         next_s, next_r = None, None
 


### PR DESCRIPTION
Improved the default selection logic for the race weekend dropdown.

Key changes:
- Reduced cache TTL for dynamic Jolpica endpoints from 30 days to 6 hours to ensure fresher "next round" data.
- Enhanced `resolve_event` logic to verify API-provided round numbers against current dates, with a robust fallback to schedule scanning if the API is stale.
- Unified the Web UI's pre-selection logic with the CLI's resolution pipeline.

Verified that the application now correctly selects Round 2 (Chinese GP) for the 2026 season given the current environment date of March 11, 2026 (Round 1 was March 8).

Fixes #221

---
*PR created automatically by Jules for task [11662610311557219588](https://jules.google.com/task/11662610311557219588) started by @2fst4u*