### PR TITLE
🎨 Palette: Add semantic context to grid gained/lost indicator

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -57,3 +57,7 @@
 ## 2026-05-24 - Ephemeral Error State UX
 **Learning:** Persistent error banners that don't offer a way to be dismissed can obscure content and leave users feeling trapped in an error state. Even if an error is temporary, providing a manual escape hatch (like an accessible "X" button) improves user autonomy.
 **Action:** Always provide an explicit dismiss/close action for error alerts or toast notifications using standard recognizable icons (`fa-times`) and focusable button elements.
+
+## 2026-03-11 - Screen Reader Context for Visual Indicators
+**Learning:** Using simple icons (like carets) and numbers to indicate changes (e.g., gained/lost positions) is visually efficient but completely opaque to screen readers. Adding `.sr-only` text and `aria-hidden="true"` to the icon ensures visually impaired users get the same context (e.g., "Gained 3 places") as sighted users.
+**Action:** Whenever using an icon + number pattern to show a delta or status change, always hide the icon from screen readers and provide descriptive `.sr-only` text alongside the value.

--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -249,9 +249,11 @@
                                                     <div class="flex flex-col items-center">
                                                         <span class="font-bold" x-text="p.grid || '--'"></span>
                                                         <template x-if="p.grid && p.grid != p.predicted_position">
-                                                            <span class="text-[10px]" :class="p.grid > p.predicted_position ? 'text-green-500' : 'text-red-500'">
-                                                                <i class="fas" :class="p.grid > p.predicted_position ? 'fa-caret-up' : 'fa-caret-down'"></i>
+                                                            <span class="text-[10px]" :class="p.grid > p.predicted_position ? 'text-green-500' : 'text-red-500'" :title="p.grid > p.predicted_position ? 'Gained ' + Math.abs(p.grid - p.predicted_position) + ' places' : 'Lost ' + Math.abs(p.grid - p.predicted_position) + ' places'">
+                                                                <i class="fas" :class="p.grid > p.predicted_position ? 'fa-caret-up' : 'fa-caret-down'" aria-hidden="true"></i>
+                                                                <span class="sr-only" x-text="p.grid > p.predicted_position ? 'Gained ' : 'Lost '"></span>
                                                                 <span x-text="Math.abs(p.grid - p.predicted_position)"></span>
+                                                                <span class="sr-only"> places</span>
                                                             </span>
                                                         </template>
                                                     </div>


### PR DESCRIPTION
💡 **What:** Added proper semantic ARIA labels and tooltips to the "grid positions gained/lost" indicator in the results table.
🎯 **Why:** Previously, the UI just showed a decorative caret icon (e.g., ▲ or ▼) and a number. Sighted users could infer the meaning, but screen readers would just read "3", with no context on whether that meant gained or lost. Now, tooltips provide explicit context on hover, and screen readers read the full context (e.g., "Gained 3 places").
📸 **Before/After:** No visual change (tooltips appear on hover). See verification screenshot in PR details.
♿ **Accessibility:** Added `aria-hidden="true"` to decorative icons, and injected `.sr-only` text blocks for context. Added `.jules/palette.md` entry.

---
*PR created automatically by Jules for task [11929333949660985504](https://jules.google.com/task/11929333949660985504) started by @2fst4u*