### PR TITLE
🎨 Palette: Lock form during prediction and improve form accessibility

### DIFF
--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -44,8 +44,8 @@
                 <div class="flex items-center space-x-2">
                     <span class="text-[10px] font-bold text-white text-opacity-60 uppercase tracking-tighter" x-text="'M:' + config.model_version"></span>
                     <span class="text-xs font-bold bg-black bg-opacity-20 px-2 py-1 rounded" x-text="'v' + config.app_version"></span>
-                    <button @click="refreshData()" aria-label="Refresh data" title="Refresh data" class="bg-black bg-opacity-20 hover:bg-opacity-30 focus:outline-none focus:ring-2 focus:ring-white p-2 rounded-full transition">
-                        <i class="fas fa-sync-alt" :class="loading ? 'animate-spin' : ''"></i>
+                    <button @click="refreshData()" :disabled="loading" aria-label="Refresh data" :title="loading ? 'Prediction in progress' : 'Refresh data'" class="bg-black bg-opacity-20 hover:bg-opacity-30 focus:outline-none focus:ring-2 focus:ring-white p-2 rounded-full transition disabled:opacity-50 disabled:cursor-not-allowed">
+                        <i class="fas fa-sync-alt" :class="loading ? 'animate-spin' : ''" aria-hidden="true"></i>
                     </button>
                 </div>
             </div>
@@ -57,8 +57,8 @@
                 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-6 items-end">
                     <div>
                         <label for="input-season" class="block text-xs font-bold text-gray-400 mb-1 uppercase tracking-wider">Season</label>
-                        <select id="input-season" x-model="params.season" @change="fetchSchedule()"
-                                class="w-full bg-gray-800 border border-gray-700 rounded p-1.5 md:p-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-red-600">
+                        <select id="input-season" x-model="params.season" @change="fetchSchedule()" :disabled="loading"
+                                class="w-full bg-gray-800 border border-gray-700 rounded p-1.5 md:p-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-red-600 disabled:opacity-50 disabled:cursor-not-allowed">
                             <option value="" x-text="seasons.length ? 'Select Season' : 'Loading seasons...'"></option>
                             <template x-for="s in seasons" :key="s.season">
                                 <option :value="s.season" x-text="s.season"></option>
@@ -67,7 +67,7 @@
                     </div>
                     <div>
                         <label for="input-round" class="block text-xs font-bold text-gray-400 mb-1 uppercase tracking-wider">Round</label>
-                        <select id="input-round" x-model="params.round" @change="fetchEventStatus()" :disabled="!params.season || scheduleLoading"
+                        <select id="input-round" x-model="params.round" @change="fetchEventStatus()" :disabled="!params.season || scheduleLoading || loading" :title="!params.season ? 'Select a season first' : (scheduleLoading ? 'Loading schedule...' : (loading ? 'Prediction in progress' : 'Select a round'))"
                                 class="w-full bg-gray-800 border border-gray-700 rounded p-1.5 md:p-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-red-600 disabled:opacity-50 disabled:cursor-not-allowed">
                             <option value="" x-text="scheduleLoading ? 'Loading rounds...' : 'Select Round'"></option>
                             <template x-for="r in schedule" :key="r.round">
@@ -80,12 +80,16 @@
                         <div class="flex flex-wrap gap-2 mt-1" role="group" aria-labelledby="sessions-label">
                             <template x-for="s in eventSessions" :key="s.id">
                                 <button @click="toggleSession(s.id)"
+                                        :disabled="loading"
                                         :aria-pressed="params.sessions.includes(s.id).toString()"
                                         :class="params.sessions.includes(s.id) ? 'bg-red-600 text-white' : 'bg-gray-800 text-gray-400'"
-                                        class="text-[10px] md:text-xs px-2 py-1 rounded border border-gray-700 hover:border-red-500 transition focus:outline-none focus:ring-2 focus:ring-red-500 flex items-center space-x-1">
+                                        class="text-[10px] md:text-xs px-2 py-1 rounded border border-gray-700 hover:border-red-500 transition focus:outline-none focus:ring-2 focus:ring-red-500 flex items-center space-x-1 disabled:opacity-50 disabled:cursor-not-allowed">
                                     <span x-text="s.id.replace('_', ' ').toUpperCase()"></span>
                                     <template x-if="s.has_results">
-                                        <i class="fas fa-check-circle text-green-400 ml-1" title="Results available"></i>
+                                        <span>
+                                            <i class="fas fa-check-circle text-green-400 ml-1" aria-hidden="true"></i>
+                                            <span class="sr-only">Results available</span>
+                                        </span>
                                     </template>
                                 </button>
                             </template>


### PR DESCRIPTION
💡 **What**:
- Disabled the Season and Round `<select>` dropdowns while a prediction is running (`loading = true`).
- Disabled the session `<button>` toggles and the top-right `Refresh data` button while a prediction is running.
- Added standard `disabled:opacity-50` and `disabled:cursor-not-allowed` styling to all of these form controls to provide clear visual feedback that they are locked.
- Added dynamic `:title` attributes to explain *why* the inputs are disabled (e.g., "Prediction in progress").
- Improved accessibility for the "refresh" icon and the "has_results" check-circle icon by explicitly hiding them from screen readers (`aria-hidden="true"`) and adding a `.sr-only` span so screen readers announce "Results available" instead of relying on standard visual cues.

🎯 **Why**:
- **Race conditions**: Users could previously modify the Season, Round, or Session selections *while* the `runPrediction` SSE stream was active. This would lead to confusing or broken application states when the stream eventually returned data for the *old* selection but the UI was set to the *new* selection.
- **Accessibility**: Screen readers often ignore or poorly interpret standard `title` attributes on `<i>` tags. Using `aria-hidden` and `.sr-only` text is the robust, semantic standard for communicating icon meaning.
- **Clarity**: Dimming out controls provides immediate visual feedback that the application is "thinking", reducing user frustration and repeated clicks.

♿ **Accessibility**:
- Added `aria-hidden="true"` to FontAwesome icons.
- Added `.sr-only` context for visual indicators.
- Added contextual disabled `title` attributes.

---
*PR created automatically by Jules for task [13215275097289127910](https://jules.google.com/task/13215275097289127910) started by @2fst4u*