### PR TITLE
🧹 Sweep: Remove unused crps_position metric function

### DIFF
--- a/f1pred/metrics.py
+++ b/f1pred/metrics.py
@@ -37,13 +37,6 @@ def brier_pairwise(pairwise_prob: np.ndarray, actual_positions: np.ndarray) -> f
 
     return float(np.mean(relevant_errors))
 
-def crps_position(prob_row: np.ndarray, actual_pos: int) -> float:
-    N = prob_row.shape[0]
-    F = np.cumsum(prob_row)
-    j_idx = np.arange(N)
-    H = (j_idx >= (actual_pos - 1)).astype(float)
-    return float(np.mean((F - H) ** 2))
-
 def compute_event_metrics(ranked_df: pd.DataFrame,
                           prob_matrix: Optional[np.ndarray],
                           pairwise: Optional[np.ndarray],

--- a/f1pred/predict.py
+++ b/f1pred/predict.py
@@ -268,7 +268,7 @@ def _run_single_prediction(
     Returns None if prediction cannot be completed.
     """
     import numpy as np
-    from .features import build_session_features, collect_historical_results, build_roster
+    from .features import build_session_features, collect_historical_results
     from .models import train_pace_model, estimate_dnf_probabilities
     from .simulate import simulate_grid
     from .ensemble import EloModel, BradleyTerryModel, MixedEffectsLikeModel, EnsembleConfig, combine_pace

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 from f1pred.metrics import (
     accuracy_top_k,
     brier_pairwise,
-    crps_position,
     compute_event_metrics,
 )
 
@@ -73,23 +72,6 @@ class TestBrierPairwise:
         ])
         score = brier_pairwise(pairwise, actual)
         assert score == pytest.approx(1.0, abs=1e-6)
-
-class TestCRPSPosition:
-    def test_winner_perfect(self):
-        prob = np.array([1.0, 0.0, 0.0])
-        actual = 1
-        assert crps_position(prob, actual) == 0.0
-
-    def test_second_place(self):
-        prob = np.array([0.5, 0.5, 0.0])
-        actual = 2
-        assert crps_position(prob, actual) == pytest.approx(0.25 / 3.0)
-
-    def test_uniform(self):
-        prob = np.array([1 / 3, 1 / 3, 1 / 3])
-        score = crps_position(prob, actual_pos=1)
-        assert score > 0
-
 
 class TestComputeEventMetrics:
     def test_basic_dataframe(self):

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1,8 +1,6 @@
 
-import pytest
 import pandas as pd
 import numpy as np
-from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 from f1pred.predict import run_predictions_for_event
 

--- a/tests/test_util_cache.py
+++ b/tests/test_util_cache.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from dataclasses import dataclass
 from unittest.mock import patch
 
-import pytest
 import numpy as np
 import pandas as pd
 


### PR DESCRIPTION
**What:**
Removed the `crps_position` function from `f1pred/metrics.py` and its corresponding unit tests and imports from `tests/test_metrics.py`.

**Why:**
The `crps_position` function was identified as unused code by Vulture. The application now uses a vectorized implementation for CRPS calculation directly inside the `compute_event_metrics` function. Removing this dead code reduces technical debt and improves maintainability.

**Verification:**
- Ran a global workspace text search (`grep -rn "crps_position" .`) which confirmed that the function was only referenced within its own definition and its tests.
- After removal, ran `make test` to ensure no active code was broken. The test suite passes.
- Ran `ruff check .` to verify code quality.

---
*PR created automatically by Jules for task [2970415488656090783](https://jules.google.com/task/2970415488656090783) started by @2fst4u*