### PR TITLE
📚 Archivist: Update CI/CD triggers and workflow names in documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ All stable releases are **manual** via GitHub Actions UI:
 | Workflow | File | Triggers | Purpose |
 |----------|------|----------|---------|
 | Tests | `tests.yml` | `workflow_call` | Reusable workflow to run pytest suite |
-| Build | `build.yml` | `push`, `pull_request`, `workflow_call`, `release` | Sequential pipeline: Tests then Build |
+| Build | `build.yml` | `push`, `workflow_call`, `release` | Sequential pipeline: Tests then Build |
 | Release | `release.yml` | Manual dispatch only | Creates semver tag + GitHub Release |
 
 ### Docker Image Tags

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Before submitting, ensure:
 
 Prerelease Docker images are built automatically on every push to any branch.
 
-For stable releases, use the **Release & Publish** workflow in GitHub Actions (manual trigger). See [AGENTS.md](AGENTS.md) for full details.
+For stable releases, use the **Release** workflow in GitHub Actions (manual trigger). See [AGENTS.md](AGENTS.md) for full details.
 
 ## Questions?
 


### PR DESCRIPTION
💡 Problem: The documentation in `AGENTS.md` and `CONTRIBUTING.md` drifted from the actual CI/CD pipeline configuration. `AGENTS.md` incorrectly claimed that `build.yml` triggered on `pull_request` (which it does not, to avoid redundant runs alongside pushes), and `CONTRIBUTING.md` referred to a phantom "Release & Publish" workflow instead of the actual "Release" workflow.
🎯 Fix: Updated `AGENTS.md` to perfectly match the REAL `.github/workflows/build.yml` triggers (`push`, `workflow_call`, `release`). Corrected the workflow name reference in `CONTRIBUTING.md` from "Release & Publish" to "Release".
🧪 Verification: Checked the actual `.github/workflows/build.yml` and `.github/workflows/release.yml` files and ran the infrastructure tests (`python -m pytest tests/test_release_config.py`).
🔎 Scope: Confirmation that this PR contains ONLY documentation changes.

---
*PR created automatically by Jules for task [2476250612262877973](https://jules.google.com/task/2476250612262877973) started by @2fst4u*