### PR TITLE
🧹 Sweep: Remove unused variables in f1pred/predict.py

### DIFF
--- a/f1pred/predict.py
+++ b/f1pred/predict.py
@@ -285,7 +285,7 @@ def _run_single_prediction(
         return None
     
     # Train pace model
-    pace_model, pace_hat, feat_cols = train_pace_model(X, session_type=sess, cfg=cfg)
+    _, pace_hat, _ = train_pace_model(X, session_type=sess, cfg=cfg)
     
     # Standardize pace
     try:
@@ -714,7 +714,7 @@ def run_predictions_for_event(
 
                         # Train pace model
                         spinner.update("Training pace model...")
-                        pace_model, pace_hat, feat_cols = train_pace_model(X, session_type=sess, cfg=cfg)
+                        _, pace_hat, _ = train_pace_model(X, session_type=sess, cfg=cfg)
 
                         # Standardize GBM pace (z-score) but preserve variance
                         try:


### PR DESCRIPTION
**💡 What:** Replaced unused variable assignments (`pace_model` and `feat_cols`) from the `train_pace_model` function call in `f1pred/predict.py` with the discard variable `_`.
**🎯 Why:** These variables were declared and assigned but never used anywhere in the subsequent logic. By using `_`, we signal explicitly that these return values are ignored without altering the function's signature, runtime logic, or overall functionality.
**🔬 Verification:** Verified the variables are unused via code inspection and static analysis (`vulture` flags and manual `grep` for variable references). Tests and `ruff check .` passed locally.

---
*PR created automatically by Jules for task [9410981339932123756](https://jules.google.com/task/9410981339932123756) started by @2fst4u*