### PR TITLE
Fix recent results grabbing regression

### DIFF
--- a/f1pred/data/fastf1_backend.py
+++ b/f1pred/data/fastf1_backend.py
@@ -89,20 +89,34 @@ def get_session_times(ev, session_name: str) -> Optional[Tuple[datetime, datetim
 
 
 def get_session_classification(season: int, round_no: int, session_name: str):
+    """Fetch session results/classification and apply patches/derivations if needed."""
     try:
         ev = get_event(season, round_no)
         if ev is None:
             return None
         sess = ev.get_session(session_name)
         sess.load(telemetry=False, laps=False, weather=False, messages=False)
+
+        # Try to get results from sess.results (often populated for finished sessions)
         results = getattr(sess, "results", None)
+
+        # Fallback to get_classification() if results is empty
+        if results is None or (hasattr(results, "empty") and results.empty):
+            try:
+                results = sess.get_classification()
+            except Exception:
+                results = None
+
         if results is not None and hasattr(results, "empty") and not results.empty:
             results = _patch_missing_positions(sess, results)
-            return results
-        try:
-            return sess.get_classification()
-        except Exception:
-            return None
+        elif results is not None and not hasattr(results, "empty"):
+            # Results exists but might not be a DataFrame (unexpected but possible)
+            pass
+        elif results is not None and hasattr(results, "empty") and results.empty:
+            # results exists but is empty DataFrame, still try to patch it via session object
+            results = _patch_missing_positions(sess, results)
+
+        return results
     except Exception:
         return None
 
@@ -118,26 +132,87 @@ def _patch_missing_positions(sess, results):
     import pandas as pd
 
     pos_col = results.get("Position")
-    if pos_col is None:
-        return results
-    if pd.to_numeric(pos_col, errors="coerce").notna().any():
+    if pos_col is not None and pd.to_numeric(pos_col, errors="coerce").notna().any():
         return results  # positions already populated, nothing to do
 
     try:
+        # 1. Attempt internal FastF1 fix for qualifying sessions (Deleted-column bug)
         # Laps may not have been loaded yet — reload with laps=True so we can
         # fix the Deleted column and recompute the classification.
         sess.load(telemetry=False, laps=True, weather=False, messages=False)
         laps = getattr(sess, "laps", None)
-        if laps is None or laps.empty:
+
+        if laps is not None and not laps.empty:
+            if "Deleted" in laps.columns and laps["Deleted"].isna().any():
+                laps["Deleted"] = laps["Deleted"].fillna(False).infer_objects(copy=False).astype(bool)
+                sess._calculate_quali_like_session_results(force=True)
+                results = getattr(sess, "results", results)
+
+                # Check if fix worked
+                pos_col = results.get("Position")
+                if pos_col is not None and pd.to_numeric(pos_col, errors="coerce").notna().any():
+                    logger.info("Patched FastF1 Deleted-column bug for %s; positions now available", sess.name)
+                    return results
+
+        # 2. Manual derivation as fallback (Q-times or Lap times)
+        return patch_missing_positions(sess.name, results)
+
+    except Exception as exc:
+        logger.debug("_patch_missing_positions failed: %s", exc)
+
+    return results
+
+
+def patch_missing_positions(session_name: str, results: 'pd.DataFrame') -> 'pd.DataFrame':
+    """Apply ranking derivation logic to a classification dataframe without needing a full session object."""
+    import pandas as pd
+    import numpy as np
+
+    pos_col = results.get("Position")
+    if pos_col is not None and pd.to_numeric(pos_col, errors="coerce").notna().any():
+        return results
+
+    try:
+        results = results.copy()
+        s_name = session_name.lower()
+        # SQ and Shootout are also quali-style
+        is_quali = any(x in s_name for x in ("qualifying", "shootout", "practice", "q", "sq"))
+
+        derived = False
+        if is_quali:
+            # Sort: Q3 > Q2 > Q1. Lower time is better.
+            q_cols = [c for c in ["Q3", "Q2", "Q1"] if c in results.columns]
+            if q_cols:
+                for c in q_cols:
+                    # Clean up strings like 'NaT' or empty before conversion
+                    if results[c].dtype == object:
+                         results[c] = results[c].astype(str).str.strip().replace(['NaT', 'nan', ''], [np.nan, np.nan, np.nan])
+
+                    if not pd.api.types.is_timedelta64_dtype(results[c]):
+                        results[c] = pd.to_timedelta(results[c], errors="coerce")
+
+                # We only derive if there's actual time data
+                if results[q_cols].notna().any().any():
+                    results = results.sort_values(by=q_cols, ascending=True, na_position='last')
+                    results["Position"] = np.arange(1, len(results) + 1)
+                    derived = True
+        else:
+            # Race/Sprint: Sort by Time (total) then BestLapTime. Lower is better.
+            t_cols = [c for c in ["Time", "BestLapTime"] if c in results.columns]
+            if t_cols:
+                for c in t_cols:
+                    if not pd.api.types.is_timedelta64_dtype(results[c]):
+                        results[c] = pd.to_timedelta(results[c], errors="coerce")
+
+                if results[t_cols].notna().any().any():
+                    results = results.sort_values(by=t_cols, ascending=True, na_position='last')
+                    results["Position"] = np.arange(1, len(results) + 1)
+                    derived = True
+
+        if derived:
+            logger.info("Derived rankings for %s from available session times", session_name)
             return results
 
-        if "Deleted" in laps.columns and laps["Deleted"].isna().any():
-            laps["Deleted"] = laps["Deleted"].fillna(False).infer_objects(copy=False).astype(bool)
-            sess._calculate_quali_like_session_results(force=True)
-            patched = getattr(sess, "results", None)
-            if patched is not None and not patched.empty:
-                logger.info("Patched FastF1 Deleted-column bug for %s; positions now available", sess.name)
-                return patched
     except Exception as exc:
         logger.debug("_patch_missing_positions failed: %s", exc)
 

--- a/f1pred/predict.py
+++ b/f1pred/predict.py
@@ -13,7 +13,7 @@ from colorama import Fore, Style
 from .util import get_logger, ensure_dirs, StatusSpinner, sanitize_for_console, PredictionCache
 from .data.jolpica import JolpicaClient
 from .data.open_meteo import OpenMeteoClient
-from .data.fastf1_backend import init_fastf1, get_session_classification, get_session_weather_status
+from .data.fastf1_backend import init_fastf1, get_session_classification, get_session_weather_status, patch_missing_positions
 
 __all__ = [
     "run_predictions_for_event",
@@ -189,13 +189,13 @@ def _get_actual_positions_for_session(
 
         # Add common fallbacks
         if sess == "race":
-            ff1_names.append("R")
+            ff1_names.extend(["Race", "R"])
         elif sess == "qualifying":
-            ff1_names.append("Q")
+            ff1_names.extend(["Qualifying", "Q"])
         elif sess == "sprint":
-            ff1_names.append("S")
+            ff1_names.extend(["Sprint", "S"])
         elif sess == "sprint_qualifying":
-            ff1_names.extend(["SQ", "Sprint Shootout", "Shootout"])
+            ff1_names.extend(["Sprint Qualifying", "SQ", "Sprint Shootout", "Shootout"])
 
         # We also need a roster to check completeness via _get_actual_positions_for_session
         if roster_view is None or roster_view.empty:
@@ -203,7 +203,11 @@ def _get_actual_positions_for_session(
 
         for ff1_sess_name in ff1_names:
             try:
+                # get_session_classification now robustly fixes and derives positions
                 cls = get_session_classification(season_i, round_i, ff1_sess_name)
+                # Final check for deriveable positions if the session just finished
+                if cls is not None:
+                     cls = patch_missing_positions(ff1_sess_name, cls)
             except Exception as e:
                 logger.debug(f"[predict] Classification fetch failed for {ff1_sess_name}: {e}")
                 cls = None
@@ -211,30 +215,10 @@ def _get_actual_positions_for_session(
             if cls is not None and hasattr(cls, "empty") and not cls.empty:
                 # Some sessions like Sprint Qualifying might have a classification
                 # but no actual positions yet if results are still being finalized.
-                pos_cols = ["Position", "ClassifiedPosition", "GridPosition"]
-                has_any_pos = False
-                for c in pos_cols:
-                    if c in cls.columns:
-                        valid_vals = pd.to_numeric(cls[c], errors="coerce").dropna()
-                        if not valid_vals.empty:
-                            has_any_pos = True
-                            break
+                pos_col = cls.get("Position")
+                has_any_pos = pos_col is not None and pd.to_numeric(pos_col, errors="coerce").notna().any()
 
                 # Special Case: Q-times check
-                if not has_any_pos:
-                    for q_col in ["Q1", "Q2", "Q3"]:
-                        if q_col in cls.columns:
-                            c_data = cls[q_col]
-                            if hasattr(c_data, 'dt'):
-                                if not c_data.dropna().empty:
-                                    has_any_pos = True
-                                    break
-                            else:
-                                s_data = c_data.astype(str).str.strip().replace(['NaT', 'nan', ''], [np.nan, np.nan, np.nan])
-                                if s_data.notna().any():
-                                    has_any_pos = True
-                                    break
-
                 if not has_any_pos:
                     logger.info(f"[predict] Classification found for {ff1_sess_name} but contains no positions yet.")
                     continue


### PR DESCRIPTION
Address session results regression by implementing robust position derivation from timing data in the FastF1 backend.

Fixes #237

---
*PR created automatically by Jules for task [3369063798264724166](https://jules.google.com/task/3369063798264724166) started by @2fst4u*