### PR TITLE
🎨 Palette: Improve table header accessibility with <abbr> tags

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -61,3 +61,7 @@
 ## 2026-03-11 - Screen Reader Context for Visual Indicators
 **Learning:** Using simple icons (like carets) and numbers to indicate changes (e.g., gained/lost positions) is visually efficient but completely opaque to screen readers. Adding `.sr-only` text and `aria-hidden="true"` to the icon ensures visually impaired users get the same context (e.g., "Gained 3 places") as sighted users.
 **Action:** Whenever using an icon + number pattern to show a delta or status change, always hide the icon from screen readers and provide descriptive `.sr-only` text alongside the value.
+
+## $(date +%Y-%m-%d) - Table Header Abbreviations with Visual Affordance
+**Learning:** Dense data tables often use abbreviations (like "Pos", "Grid", "DNF") to save horizontal space, especially on mobile. While visually efficient, these are often ambiguous to new users and lack clarity for screen readers. Using the semantic `<abbr>` tag solves both: it provides the full text on hover/focus (via the `title` attribute) and can be styled (e.g., dotted underline) to indicate it's interactive.
+**Action:** When abbreviating column headers to save space, wrap the text in an `<abbr>` tag with a descriptive `title` attribute. Style it with a dotted underline and a help cursor to provide a clear affordance that more information is available on hover.

--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -219,19 +219,19 @@
                                 <table class="w-full text-left">
                                     <thead>
                                         <tr class="bg-gray-800 text-[10px] sm:text-xs font-bold text-gray-400 uppercase tracking-wider">
-                                            <th class="px-0.5 py-2 sm:p-4 w-7 sm:w-12 text-center">Pos</th>
-                                            <th class="px-0.5 py-2 sm:p-4">Driver</th>
-                                            <th class="px-0.5 py-2 sm:p-4 hidden md:table-cell">Team</th>
-                                            <th class="px-0.5 py-2 sm:p-4 text-center" x-show="hasGrid(sess)">Grid</th>
-                                            <th class="px-0.5 py-2 sm:p-4">
+                                            <th scope="col" class="px-0.5 py-2 sm:p-4 w-7 sm:w-12 text-center"><abbr title="Predicted Position" class="cursor-help underline decoration-dotted decoration-gray-500 underline-offset-4 hover:text-white transition-colors">Pos</abbr></th>
+                                            <th scope="col" class="px-0.5 py-2 sm:p-4">Driver</th>
+                                            <th scope="col" class="px-0.5 py-2 sm:p-4 hidden md:table-cell">Team</th>
+                                            <th scope="col" class="px-0.5 py-2 sm:p-4 text-center" x-show="hasGrid(sess)"><abbr title="Starting Grid Position" class="cursor-help underline decoration-dotted decoration-gray-500 underline-offset-4 hover:text-white transition-colors">Grid</abbr></th>
+                                            <th scope="col" class="px-0.5 py-2 sm:p-4">
                                                 <span class="hidden sm:inline">Win Prob</span>
                                                 <span class="sm:hidden">Win %</span>
                                             </th>
-                                            <th class="px-0.5 py-2 sm:p-4">
+                                            <th scope="col" class="px-0.5 py-2 sm:p-4">
                                                 <span class="hidden sm:inline">Podium</span>
                                                 <span class="sm:hidden">Top 3</span>
                                             </th>
-                                            <th class="px-0.5 py-2 sm:p-4 text-right">DNF</th>
+                                            <th scope="col" class="px-0.5 py-2 sm:p-4 text-right"><abbr title="Did Not Finish Probability" class="cursor-help underline decoration-dotted decoration-gray-500 underline-offset-4 hover:text-white transition-colors">DNF</abbr></th>
                                         </tr>
                                     </thead>
                                     <tbody class="divide-y divide-gray-800">


### PR DESCRIPTION
💡 **What**: Added semantic `<abbr>` tags and visual affordances (dotted underline, help cursor) to abbreviated column headers ("Pos", "Grid", "DNF") in the results table, along with `scope="col"` on all table headers.
🎯 **Why**: Dense data tables often use abbreviations to save space, which can be ambiguous to users and opaque to screen readers. Wrapping them provides the full context on hover/focus while retaining the compact layout.
📸 **Before/After**: The headers now have a subtle dotted underline indicating they can be interacted with for more info.
♿ **Accessibility**: Screen readers will now announce the full descriptive text (e.g., "Predicted Position" instead of "Pos"). Added `scope="col"` ensures table structure is properly interpreted by assistive tech.

---
*PR created automatically by Jules for task [208353310792330235](https://jules.google.com/task/208353310792330235) started by @2fst4u*