### PR TITLE
Fix stale round selection in Web UI

### DIFF
--- a/f1pred/predict.py
+++ b/f1pred/predict.py
@@ -43,11 +43,11 @@ def resolve_event(jc: JolpicaClient, season: Optional[str], rnd: str) -> Tuple[i
                     races = jc.get_season_schedule(str(s))
                     this_race = next((x for x in races if str(x.get("round")) == str(r)), None)
                     if this_race:
-                        race_dt = datetime.fromisoformat(this_race["date"] + "T00:00:00+00:00")
+                        race_dt = _get_session_datetime(this_race, "race") or datetime.fromisoformat(this_race["date"] + "T00:00:00+00:00")
                         now = datetime.now(timezone.utc)
-                        # If the race was more than 1 day ago, it's likely stale
-                        if race_dt < now - timedelta(days=1):
-                            future = [x for x in races if datetime.fromisoformat(x["date"] + "T00:00:00+00:00") >= now - timedelta(days=1)]
+                        # If the race was more than 4 hours ago, it's likely stale
+                        if race_dt < now - timedelta(hours=4):
+                            future = [x for x in races if (_get_session_datetime(x, "race") or datetime.fromisoformat(x["date"] + "T00:00:00+00:00")) >= now - timedelta(hours=4)]
                             if future:
                                 r = future[0]["round"]
                 except Exception:
@@ -55,7 +55,7 @@ def resolve_event(jc: JolpicaClient, season: Optional[str], rnd: str) -> Tuple[i
                     s, _ = jc.get_latest_season_and_round()
                     races = jc.get_season_schedule(str(s))
                     now = datetime.now(timezone.utc)
-                    future = [x for x in races if datetime.fromisoformat(x["date"] + "T00:00:00+00:00") >= now - timedelta(days=1)]
+                    future = [x for x in races if (_get_session_datetime(x, "race") or datetime.fromisoformat(x["date"] + "T00:00:00+00:00")) >= now - timedelta(hours=4)]
                     r = future[0]["round"] if future else races[-1]["round"]
             elif rnd == "last":
                 s, r = jc.get_latest_season_and_round()
@@ -79,7 +79,7 @@ def resolve_event(jc: JolpicaClient, season: Optional[str], rnd: str) -> Tuple[i
                         r = races[-1]["round"]
                 else:
                     now = datetime.now(timezone.utc)
-                    future = [x for x in races if datetime.fromisoformat(x["date"] + "T00:00:00+00:00") >= now]
+                    future = [x for x in races if (_get_session_datetime(x, "race") or datetime.fromisoformat(x["date"] + "T00:00:00+00:00")) >= now - timedelta(hours=4)]
                     r = future[0]["round"] if future else races[-1]["round"]
             else:
                 r = rnd


### PR DESCRIPTION
The application now more accurately determines the "next" F1 round by using both the date and time of the race sessions from the Jolpica API. The threshold for considering a round "stale" has been reduced from 24 hours to 4 hours after the scheduled race start. This ensures that the Web UI correctly advances to the next upcoming race (e.g., from the Chinese GP to the Japan GP) shortly after the current race concludes, rather than lagging for a full day.

Fixes #250

---
*PR created automatically by Jules for task [11340285744202308726](https://jules.google.com/task/11340285744202308726) started by @2fst4u*