### PR TITLE
🎨 Palette: Improve screen reader accessibility for terminal UI and version badges

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -65,3 +65,11 @@
 ## $(date +%Y-%m-%d) - Table Header Abbreviations with Visual Affordance
 **Learning:** Dense data tables often use abbreviations (like "Pos", "Grid", "DNF") to save horizontal space, especially on mobile. While visually efficient, these are often ambiguous to new users and lack clarity for screen readers. Using the semantic `<abbr>` tag solves both: it provides the full text on hover/focus (via the `title` attribute) and can be styled (e.g., dotted underline) to indicate it's interactive.
 **Action:** When abbreviating column headers to save space, wrap the text in an `<abbr>` tag with a descriptive `title` attribute. Style it with a dotted underline and a help cursor to provide a clear affordance that more information is available on hover.
+
+## $(date +%Y-%m-%d) - Simulating Terminal UIs in HTML
+**Learning:** When building simulated terminal interfaces in the browser, decorative characters like the command prompt `>` or progress indicators `...` create immense noise for screen reader users, who will hear them read literally (e.g., "greater than"). Additionally, visually pulsed or appended text won't be announced automatically.
+**Action:** Always add `aria-hidden="true"` to literal terminal syntax characters. Wrap the dynamic log container or specific lines with `aria-live="polite"` (or `"assertive"`) so that screen readers proactively read the simulated terminal output updates without requiring manual user navigation.
+
+## $(date +%Y-%m-%d) - Abbreviated Badges and Screen Readers
+**Learning:** Tiny prefixes used in UI badges (like "v" for version or "M:" for model) lack context and are read confusingly by screen readers as standalone letters.
+**Action:** For single-letter or abbreviated visual badges, hide the abbreviation using `aria-hidden="true"` and provide the full context in an adjacent `<span class="sr-only">` (e.g., "App Version").

--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -42,8 +42,12 @@
             <div class="container mx-auto flex justify-between items-center">
                 <h1 class="text-2xl font-black tracking-tighter italic">F1 OUTCOME PREDICTOR</h1>
                 <div class="flex items-center space-x-2">
-                    <span class="text-[10px] font-bold text-white text-opacity-60 uppercase tracking-tighter" x-text="'M:' + config.model_version"></span>
-                    <span class="text-xs font-bold bg-black bg-opacity-20 px-2 py-1 rounded" x-text="'v' + config.app_version"></span>
+                    <span class="text-[10px] font-bold text-white text-opacity-60 uppercase tracking-tighter">
+                        <span class="sr-only">Model Version </span><span aria-hidden="true">M:</span><span x-text="config.model_version"></span>
+                    </span>
+                    <span class="text-xs font-bold bg-black bg-opacity-20 px-2 py-1 rounded">
+                        <span class="sr-only">App Version </span><span aria-hidden="true">v</span><span x-text="config.app_version"></span>
+                    </span>
                     <button @click="refreshData()" :disabled="loading" aria-label="Refresh data" :title="loading ? 'Prediction in progress' : 'Refresh data'" class="bg-black bg-opacity-20 hover:bg-opacity-30 focus:outline-none focus:ring-2 focus:ring-white p-2 rounded-full transition disabled:opacity-50 disabled:cursor-not-allowed">
                         <i class="fas fa-sync-alt" :class="loading ? 'animate-spin' : ''" aria-hidden="true"></i>
                     </button>
@@ -135,17 +139,17 @@
                     <i class="fas fa-terminal mr-2 text-blue-400" aria-hidden="true"></i>
                     <h3 class="text-xs font-bold uppercase tracking-widest text-gray-400">Prediction Progress</h3>
                 </div>
-                <div class="bg-black bg-opacity-30 rounded p-3 font-mono text-xs h-32 overflow-y-auto space-y-1" id="log-container">
+                <div class="bg-black bg-opacity-30 rounded p-3 font-mono text-xs h-32 overflow-y-auto space-y-1" id="log-container" aria-live="polite">
                     <template x-for="log in logs">
                         <div class="flex">
-                            <span class="text-blue-500 mr-2">></span>
+                            <span class="text-blue-500 mr-2" aria-hidden="true">></span>
                             <span class="text-gray-300" x-text="log"></span>
                         </div>
                     </template>
                     <div class="flex items-center text-blue-400 animate-pulse">
-                        <span class="mr-2">></span>
+                        <span class="mr-2" aria-hidden="true">></span>
                         <span x-text="currentLog"></span>
-                        <span class="ml-1">...</span>
+                        <span class="ml-1" aria-hidden="true">...</span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
💡 **What**: Improved screen reader accessibility in the F1 Predictor web UI by addressing literal character reading in simulated terminal logs and version badges. Added ARIA live regions for continuous progress updates.
🎯 **Why**: Screen readers previously read decorative characters like `>` as "greater than" and `...` as "dot dot dot", causing significant noise during long predictions. Abbreviated badges ("M:", "v") lacked context. Adding `aria-hidden` and `.sr-only` provides a clean, descriptive auditory experience without altering the visual design.
📸 **Before/After**: Visually identical; auditory experience is streamlined.
♿ **Accessibility**: 
- Added `aria-hidden="true"` to terminal prompts and trailing dots.
- Added `aria-live="polite"` to the `<div id="log-container">` to announce updates automatically.
- Replaced literal readouts of "M:" and "v" with "Model Version" and "App Version" for screen reader context.

---
*PR created automatically by Jules for task [4036940151213522401](https://jules.google.com/task/4036940151213522401) started by @2fst4u*