### PR TITLE
📚 Archivist: Update README to include precipitation_unit

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -1,3 +1,3 @@
-## 2024-05-24 - [Resolve Pytest Local Module Execution Issues]
-**Learning:** Local execution using the `pytest` standalone binary can fail to resolve local modules in this specific virtual environment setup, resulting in ModuleNotFoundError. Relying solely on the `pytest` command creates a barrier to entry for contributors and creates inconsistency between local runs and CI.
-**Action:** Always use `python -m pytest` instead of `pytest` across all scripts, CI, and documentation to ensure reliable execution and module resolution in all environments. Ensure `pytest-cov` is installed alongside `pytest` since the project explicitly tracks coverage and specifies a `fail_under` threshold in `pyproject.toml`.
+## 2024-03-10 - Undocumented Configuration Drift
+**Learning:** Configuration options often get added to `config.yaml` and validation logic (`f1pred/config.py`) without corresponding updates in `README.md`, causing documentation to drift from actual supported behavior.
+**Action:** When auditing configuration options, cross-reference `config.yaml` values explicitly against the `README.md` to spot undocumented parameters (like `precipitation_unit`).

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ data_sources:
   open_meteo:
     temperature_unit: "celsius" # or fahrenheit
     windspeed_unit: "kmh" # kmh, ms, mph, kn
+    precipitation_unit: "mm" # mm, inch
 ```
 
 ## Output


### PR DESCRIPTION
💡 Problem: The `README.md` file documented the `temperature_unit` and `windspeed_unit` configuration options for `open_meteo`, but completely omitted `precipitation_unit` which is an active and validated configuration setting present in `config.yaml`.
🎯 Fix: Added `precipitation_unit: "mm" # mm, inch` to the `data_sources.open_meteo` configuration block in `README.md`.
🧪 Verification: Checked `config.yaml` and `f1pred/config.py` which validate `precipitation_unit`. Ran test suite (`make test`) and linter (`ruff check .`) successfully.
🔎 Scope: ONLY documentation (`README.md`) and agent learnings journal (`.jules/archivist.md`) were modified.

---
*PR created automatically by Jules for task [4987736231309120775](https://jules.google.com/task/4987736231309120775) started by @2fst4u*