### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS vulnerability by limiting list lengths on predict endpoints

### DIFF
--- a/f1pred/calibrate.py
+++ b/f1pred/calibrate.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
-from typing import Dict, Any, Optional, Tuple, TYPE_CHECKING
+from typing import Dict, Any, Optional, TYPE_CHECKING
 from datetime import datetime, timedelta, timezone
 from concurrent.futures import ThreadPoolExecutor
 

--- a/f1pred/config.py
+++ b/f1pred/config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import List, Any, Dict, Optional
 from pathlib import Path
 import os

--- a/f1pred/web.py
+++ b/f1pred/web.py
@@ -205,6 +205,10 @@ async def get_predictions(
     if not _config:
          raise HTTPException(status_code=500, detail="Application not configured")
 
+    # 🛡️ Sentinel: Prevent DoS via unbounded list input
+    if sessions and len(sessions) > 10:
+        raise HTTPException(status_code=400, detail="Too many sessions requested")
+
     try:
         # Use default sessions if not provided
         target_sessions = sessions or _config.modelling.targets.session_types
@@ -261,6 +265,10 @@ async def get_predictions_stream(
 ):
     if not _config:
          raise HTTPException(status_code=500, detail="Application not configured")
+
+    # 🛡️ Sentinel: Prevent DoS via unbounded list input
+    if sessions and len(sessions) > 10:
+        raise HTTPException(status_code=400, detail="Too many sessions requested")
 
     def run_and_collect(q: queue.Queue):
         try:

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -1,0 +1,28 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from f1pred.web import app, init_web
+from f1pred.config import load_config
+
+@pytest.fixture
+def client():
+    # Use real config for simple init
+    cfg = load_config("config.yaml")
+    init_web(cfg)
+    return TestClient(app)
+
+def test_get_predict_too_many_sessions(client):
+    # Pass 11 session parameters
+    sessions = ["race"] * 11
+    url = "/api/predict?" + "&".join([f"sessions={s}" for s in sessions])
+    response = client.get(url)
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Too many sessions requested"}
+
+def test_get_predict_stream_too_many_sessions(client):
+    # Pass 11 session parameters
+    sessions = ["race"] * 11
+    url = "/api/predict/stream?" + "&".join([f"sessions={s}" for s in sessions])
+    response = client.get(url)
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Too many sessions requested"}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The FastAPI endpoints `/api/predict` and `/api/predict/stream` accept `sessions` as a `List[str] = Query(None, max_length=20)`. The `max_length` parameter validates the length of the strings *within* the list, but it does NOT enforce a limit on the number of items in the list itself. An attacker could potentially send an unbounded list of strings, causing a Denial of Service via resource exhaustion.
🎯 Impact: High resource consumption or potential DoS leading to application downtime.
🔧 Fix: Added explicit length checks (`len(sessions) > 10`) at the start of the endpoint functions to raise a 400 Bad Request if the list size exceeds a reasonable bound. Added tests in `tests/test_web_security.py` to verify the patch.
✅ Verification: Ran `make test` successfully and created tests `test_get_predict_too_many_sessions` and `test_get_predict_stream_too_many_sessions` that verify the application rejects excessive list parameters.

---
*PR created automatically by Jules for task [14280571637328156997](https://jules.google.com/task/14280571637328156997) started by @2fst4u*