### PR TITLE
🎨 Palette: Hide decorative progress bars from screen readers

### DIFF
--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -271,7 +271,7 @@
                                                         <div class="flex justify-between text-[10px] mb-0.5 sm:mb-1">
                                                             <span x-text="(p.p_win * 100).toFixed(1) + '%'"></span>
                                                         </div>
-                                                        <div class="progress-bar hidden sm:block">
+                                                        <div class="progress-bar hidden sm:block" aria-hidden="true">
                                                             <div class="progress-fill" :style="'width: ' + (p.p_win * 100) + '%; background-color: ' + getProbColor(p.p_win * 100)"></div>
                                                         </div>
                                                     </div>
@@ -281,7 +281,7 @@
                                                         <div class="flex justify-between text-[10px] mb-0.5 sm:mb-1">
                                                             <span x-text="(p.p_top3 * 100).toFixed(1) + '%'"></span>
                                                         </div>
-                                                        <div class="progress-bar hidden sm:block">
+                                                        <div class="progress-bar hidden sm:block" aria-hidden="true">
                                                             <div class="progress-fill" :style="'width: ' + (p.p_top3 * 100) + '%; background-color: ' + getProbColor(p.p_top3 * 100)"></div>
                                                         </div>
                                                     </div>
@@ -291,7 +291,7 @@
                                                         <div class="flex justify-between text-[10px] mb-0.5 sm:mb-1">
                                                             <span x-text="(p.p_dnf * 100).toFixed(1) + '%'"></span>
                                                         </div>
-                                                        <div class="progress-bar hidden sm:block">
+                                                        <div class="progress-bar hidden sm:block" aria-hidden="true">
                                                             <div class="progress-fill" :style="'width: ' + (p.p_dnf * 100) + '%; background-color: ' + getProbColor(p.p_dnf * 100, true)"></div>
                                                         </div>
                                                     </div>


### PR DESCRIPTION
**💡 What:**
Added `aria-hidden="true"` to the three visual progress bars (Win Prob, Podium, and DNF) in the prediction results table (`f1pred/templates/index.html`).

**🎯 Why:**
The exact probability percentages are already rendered as text immediately preceding the visual bars. Without `aria-hidden`, screen readers traverse these empty HTML structural `div`s, causing redundant or confusing announcements.

**♿ Accessibility:**
This change hides purely decorative visual elements from screen reading tools, improving the overall semantic structure and reducing auditory clutter for users relying on assistive technologies.

---
*PR created automatically by Jules for task [6197258643208440265](https://jules.google.com/task/6197258643208440265) started by @2fst4u*