### PR TITLE
📚 Archivist: Update README to clarify dynamic weight calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,9 @@ All settings live in `config.yaml`. The main things you might want to tweak:
 
 ```yaml
 modelling:
-  recency_half_life_days:
-    base: 120 # How quickly old results fade in importance
-    weather: 180 # Weather skill memory
-    team: 240 # Team performance memory
+  # Model weights (including recency, blending, ensemble, DNF)
+  # are dynamically calibrated at runtime.
+  # Delete calibration_weights.json to force full re-calibration.
   monte_carlo:
     draws: 5000 # Simulation iterations (more = slower but smoother)
 


### PR DESCRIPTION
💡 **Problem:** 
The `README.md` file contained a "Configuration" section that explicitly listed `recency_half_life_days` under `modelling` as a value to tweak in `config.yaml`. However, the actual codebase (`f1pred/calibrate.py`) has since been updated to dynamically calibrate all model weights (including recency, blending, ensemble, and DNF weights) at runtime via a `CalibrationManager`. This caused the documentation to drift from actual supported behavior, presenting a configurable option that is largely ignored or overwritten at runtime.

🎯 **Fix:** 
Updated the `README.md` to remove the outdated `recency_half_life_days` example from the `config.yaml` snippet. Replaced it with a clear, factual note explaining that model weights are dynamically calibrated at runtime and that users can force a full re-calibration by deleting `calibration_weights.json` (mirroring the internal comments found in the actual `config.yaml`).

🧪 **Verification:** 
- Cross-referenced `config.yaml` and `f1pred/config.py` to confirm `recency_half_life_days` is no longer statically initialized as `180` for weather and `240` for team.
- Read `f1pred/calibrate.py` to confirm the dynamic calibration behavior.
- Ran the linter (`ruff check .`) and full test suite (`make test`) to ensure no regressions or pipeline breakages were introduced by this documentation change.

🔎 **Scope:** 
This PR contains ONLY documentation changes to `README.md`.

---
*PR created automatically by Jules for task [4775964558052660909](https://jules.google.com/task/4775964558052660909) started by @2fst4u*