### PR TITLE
📚 Archivist: Update test suite dependencies

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -1,3 +1,7 @@
 ## 2024-03-10 - Undocumented Configuration Drift
 **Learning:** Configuration options often get added to `config.yaml` and validation logic (`f1pred/config.py`) without corresponding updates in `README.md`, causing documentation to drift from actual supported behavior.
 **Action:** When auditing configuration options, cross-reference `config.yaml` values explicitly against the `README.md` to spot undocumented parameters (like `precipitation_unit`).
+
+## 2024-03-10 - Test Dependency Drift
+**Learning:** The development environment requires manual installation of test and runtime tools (`playwright`, `fastparquet`, `pyarrow`, `colorama`) beyond the base dependencies in `requirements.txt`. The `README.md` instructions frequently drift from the actual required sequence.
+**Action:** When updating test instructions, ensure the sequence explicitly includes `make install` followed by the manual installation of all test dependencies before running `make test`.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ python main.py --backtest
 Run the local test suite (requires installing test dependencies first):
 
 ```bash
-pip install pytest pytest-cov httpx
+make install
+pip install pytest pytest-cov httpx playwright fastparquet pyarrow colorama
 make test
 ```
 


### PR DESCRIPTION
💡 **Problem:** The test suite instructions in the `README.md` were incomplete and lacked several manual dependency installations (`playwright`, `fastparquet`, `pyarrow`, `colorama`). Running `make test` directly after following the provided instructions would fail due to missing dependencies.

🎯 **Fix:** Updated the `README.md` testing instructions to precisely mirror the required sequence for standard development environments: running `make install` first, then installing the full list of missing test dependencies (`pytest pytest-cov httpx playwright fastparquet pyarrow colorama`), and then running `make test`. Additionally, recorded the finding about test dependency drift in the `.jules/archivist.md` journal.

🧪 **Verification:** Validated that the new sequence `make install && pip install pytest pytest-cov httpx playwright fastparquet pyarrow colorama && make test` successfully executes the test suite in the local environment without errors. Checked `.github/workflows/tests.yml` to confirm standard dependency management structure. 

🔎 **Scope:** This PR strictly contains updates to `README.md` testing instructions and a new entry in the `.jules/archivist.md` learning journal. No application behavior or code was modified.

---
*PR created automatically by Jules for task [9847091422921082480](https://jules.google.com/task/9847091422921082480) started by @2fst4u*