### PR TITLE
🎨 Palette: Expand desktop layout and fix horizontal scrolling

### DIFF
--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -41,7 +41,7 @@
     <div class="min-h-screen">
         <!-- Header -->
         <header class="f1-red shadow-lg p-4">
-            <div class="container mx-auto flex justify-between items-center flex-wrap gap-2">
+            <div class="max-w-[1400px] w-full mx-auto flex justify-between items-center flex-wrap gap-2">
                 <h1 class="text-xl md:text-2xl font-black tracking-tighter italic whitespace-nowrap">F1 OUTCOME PREDICTOR</h1>
                 <div class="flex items-center space-x-2 min-w-0">
                     <span class="text-[10px] font-bold text-white text-opacity-60 uppercase tracking-tighter truncate max-w-[80px] sm:max-w-none inline-block">
@@ -57,7 +57,7 @@
             </div>
         </header>
 
-        <main class="container mx-auto px-2 py-4 md:p-8">
+        <main class="max-w-[1400px] w-full mx-auto px-2 py-4 md:p-8">
             <!-- Controls -->
             <div class="card p-4 md:p-6 mb-4 md:mb-8 shadow-xl">
                 <div class="grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-6 items-end">
@@ -301,7 +301,7 @@
                                             </tr>
                                             <!-- Influence panel — now in its own row, spanning all columns -->
                                             <tr :class="getTeamClass(p.constructorName)" x-show="p.ensemble_components || hasShapFactors(p.shap_values)">
-                                                <td colspan="7" class="px-2 sm:px-12 pb-3 border-t border-gray-800/50">
+                                                <td colspan="7" class="px-2 md:px-8 lg:px-12 pb-3 border-t border-gray-800/50">
                                                     <div class="flex flex-wrap md:flex-nowrap gap-x-8 gap-y-4 items-start">
                                                         <!-- Model Mix bar -->
                                                         <template x-if="p.ensemble_components">
@@ -327,7 +327,7 @@
                                                                 <div class="text-[9px] font-bold text-gray-500 uppercase tracking-widest mb-0.5">
                                                                     Factors <span class="normal-case font-normal text-gray-600">(green = helps, red = hurts)</span>
                                                                 </div>
-                                                                <div class="flex flex-nowrap gap-x-1.5 sm:gap-x-2 gap-y-0.5 overflow-x-auto no-scrollbar">
+                                                                <div class="flex flex-nowrap md:flex-wrap gap-x-1.5 sm:gap-x-2 gap-y-0.5 overflow-x-auto md:overflow-visible no-scrollbar">
                                                                     <template x-for="feat in getSortedShap(p.shap_values)" :key="feat.key">
                                                                         <div class="flex items-center flex-shrink-0 gap-0.5 text-[8px] sm:text-[9px]">
                                                                             <span class="sr-only" x-text="feat.val < 0 ? 'Improves position:' : 'Worsens position:'"></span>


### PR DESCRIPTION
### 🎨 Palette: Expand desktop layout and fix horizontal scrolling

#### 💡 What
This PR improves the desktop user experience of the F1 Outcome Predictor by expanding the available content area and eliminating internal horizontal scrolling within the prediction results.

- The main layout container (header and main tags) has been widened from the default Tailwind `container` to `max-w-[1400px] w-full mx-auto`.
- The SHAP factors list within the driver influence panel now wraps on desktop (`md:flex-wrap`) instead of forcing a horizontal scrollbar (`flex-nowrap overflow-x-auto`).
- Horizontal padding for the influence panel has been refined to be more responsive (`px-2 md:px-8 lg:px-12`).

#### 🎯 Why
The previous layout was too restrictive on large desktop screens, causing dense prediction data (especially SHAP factors) to be hidden behind a horizontal scrollbar despite ample screen real estate being available to the sides.

#### 📸 Before/After
- **Before:** Results sat in a narrower container; factors list always scrolled horizontally on desktop.
- **After:** Results expand to 1400px; factors wrap naturally on desktop, utilizing the extra width.

#### ♻️ Accessibility
- Maintained `overflow-x-auto` on mobile devices where horizontal scrolling is the expected and preferred behavior for dense tabular/grid data.
- All decorative icons and layout changes preserve existing `aria-hidden` and `sr-only` context.

#### 🔬 Verification
- Visual verification performed using Playwright screenshots at 1440x900 and 1000px widths.
- Full test suite passed with `make test` (327/327 tests, 66.61% coverage).

Fixes #289

---
*PR created automatically by Jules for task [12815354775506811840](https://jules.google.com/task/12815354775506811840) started by @2fst4u*