### PR TITLE
🎨 Palette: Standardize small font sizes and improve readability

### DIFF
--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -44,7 +44,7 @@
             <div class="max-w-[1400px] w-full mx-auto flex justify-between items-center flex-wrap gap-2">
                 <h1 class="text-xl md:text-2xl font-black tracking-tighter italic whitespace-nowrap">F1 OUTCOME PREDICTOR</h1>
                 <div class="flex items-center space-x-2 min-w-0">
-                    <span class="text-[10px] font-bold text-white text-opacity-60 uppercase tracking-tighter truncate max-w-[80px] sm:max-w-none inline-block">
+                    <span class="text-xs font-bold text-white text-opacity-60 uppercase tracking-tighter truncate max-w-[80px] sm:max-w-none inline-block">
                         <span class="sr-only">Model Version </span><span aria-hidden="true">M:</span><span x-text="config.model_version"></span>
                     </span>
                     <span class="text-xs font-bold bg-black bg-opacity-20 px-2 py-1 rounded truncate max-w-[60px] sm:max-w-none inline-block">
@@ -89,7 +89,7 @@
                                         :disabled="loading"
                                         :aria-pressed="params.sessions.includes(s.id).toString()"
                                         :class="params.sessions.includes(s.id) ? 'bg-red-600 text-white' : 'bg-gray-800 text-gray-400'"
-                                        class="text-[10px] md:text-xs px-2 py-1 rounded border border-gray-700 hover:border-red-500 transition focus:outline-none focus:ring-2 focus:ring-red-500 flex items-center space-x-1 disabled:opacity-50 disabled:cursor-not-allowed">
+                                        class="text-xs px-2 py-1 rounded border border-gray-700 hover:border-red-500 transition focus:outline-none focus:ring-2 focus:ring-red-500 flex items-center space-x-1 disabled:opacity-50 disabled:cursor-not-allowed">
                                     <span x-text="s.id.replace('_', ' ').toUpperCase()"></span>
                                     <template x-if="s.has_results">
                                         <span>
@@ -100,7 +100,7 @@
                                 </button>
                             </template>
                             <template x-if="statusLoading">
-                                <span class="text-[10px] md:text-xs px-2 py-1 text-gray-400 italic flex items-center">
+                                <span class="text-xs px-2 py-1 text-gray-400 italic flex items-center">
                                     <i class="fas fa-circle-notch fa-spin mr-1.5" aria-hidden="true"></i> Loading...
                                 </span>
                             </template>
@@ -194,7 +194,7 @@
                                 <div class="card p-1 md:p-3 flex items-center space-x-1 md:space-x-3">
                                     <div class="text-lg md:text-2xl text-yellow-500"><i class="fas fa-thermometer-half" aria-hidden="true"></i></div>
                                     <div>
-                                        <div class="text-[10px] md:text-xs text-gray-400 uppercase">Temp</div>
+                                        <div class="text-xs text-gray-400 uppercase">Temp</div>
                                         <div class="font-bold text-xs md:text-base" x-text="Math.round(data.weather.temp_mean) + '°C'"></div>
                                     </div>
                                 </div>
@@ -203,7 +203,7 @@
                                 <div class="card p-1 md:p-3 flex items-center space-x-1 md:space-x-3">
                                     <div class="text-lg md:text-2xl text-blue-500"><i class="fas fa-cloud-rain" aria-hidden="true"></i></div>
                                     <div>
-                                        <div class="text-[10px] md:text-xs text-gray-400 uppercase">Rain</div>
+                                        <div class="text-xs text-gray-400 uppercase">Rain</div>
                                         <div class="font-bold text-xs md:text-base" x-text="data.weather.rain_sum.toFixed(1) + 'mm'"></div>
                                     </div>
                                 </div>
@@ -212,7 +212,7 @@
                                 <div class="card p-1 md:p-3 flex items-center space-x-1 md:space-x-3">
                                     <div class="text-lg md:text-2xl text-gray-400"><i class="fas fa-wind" aria-hidden="true"></i></div>
                                     <div>
-                                        <div class="text-[10px] md:text-xs text-gray-400 uppercase">Wind</div>
+                                        <div class="text-xs text-gray-400 uppercase">Wind</div>
                                         <div class="font-bold text-xs md:text-base" x-text="Math.round(data.weather.wind_mean) + 'km/h'"></div>
                                     </div>
                                 </div>
@@ -224,7 +224,7 @@
                             <div class="overflow-x-auto">
                                 <table class="w-full text-left">
                                     <thead>
-                                        <tr class="bg-gray-800 text-[10px] sm:text-xs font-bold text-gray-400 uppercase tracking-wider">
+                                        <tr class="bg-gray-800 text-xs font-bold text-gray-400 uppercase tracking-wider">
                                             <th scope="col" class="px-0.5 py-2 sm:p-4 w-7 sm:w-12 text-center"><abbr title="Predicted Position" class="cursor-help underline decoration-dotted decoration-gray-500 underline-offset-4 hover:text-white transition-colors">Pos</abbr></th>
                                             <th scope="col" class="px-0.5 py-2 sm:p-4">Driver</th>
                                             <th scope="col" class="px-0.5 py-2 sm:p-4 hidden md:table-cell">Team</th>
@@ -263,7 +263,7 @@
                                                     <div class="flex flex-col items-center">
                                                         <span class="font-bold" x-text="p.grid || '--'"></span>
                                                         <template x-if="p.grid && p.grid != p.predicted_position">
-                                                            <span class="text-[10px]" :class="p.grid > p.predicted_position ? 'text-green-500' : 'text-red-500'">
+                                                            <span class="text-xs" :class="p.grid > p.predicted_position ? 'text-green-500' : 'text-red-500'">
                                                                 <span class="sr-only" x-text="p.grid > p.predicted_position ? 'Improves position by:' : 'Worsens position by:'"></span>
                                                                 <i class="fas" :class="p.grid > p.predicted_position ? 'fa-caret-up' : 'fa-caret-down'" aria-hidden="true"></i>
                                                                 <span x-text="Math.abs(p.grid - p.predicted_position)"></span>
@@ -274,7 +274,7 @@
                                                 <!-- Win % -->
                                                 <td class="px-0.5 pt-2 sm:pt-4 px-0.5 sm:px-4 align-top">
                                                     <div class="w-10 sm:w-24">
-                                                        <div class="text-[10px] mb-0.5 sm:mb-1" x-text="(p.p_win * 100).toFixed(1) + '%'"></div>
+                                                        <div class="text-xs mb-0.5 sm:mb-1" x-text="(p.p_win * 100).toFixed(1) + '%'"></div>
                                                         <div class="progress-bar hidden sm:block" aria-hidden="true">
                                                             <div class="progress-fill" :style="'width: ' + (p.p_win * 100) + '%; background-color: ' + getProbColor(p.p_win * 100)"></div>
                                                         </div>
@@ -283,7 +283,7 @@
                                                 <!-- Top 3 % -->
                                                 <td class="px-0.5 pt-2 sm:pt-4 px-0.5 sm:px-4 align-top">
                                                     <div class="w-10 sm:w-24">
-                                                        <div class="text-[10px] mb-0.5 sm:mb-1" x-text="(p.p_top3 * 100).toFixed(1) + '%'"></div>
+                                                        <div class="text-xs mb-0.5 sm:mb-1" x-text="(p.p_top3 * 100).toFixed(1) + '%'"></div>
                                                         <div class="progress-bar hidden sm:block" aria-hidden="true">
                                                             <div class="progress-fill" :style="'width: ' + (p.p_top3 * 100) + '%; background-color: ' + getProbColor(p.p_top3 * 100)"></div>
                                                         </div>
@@ -292,7 +292,7 @@
                                                 <!-- DNF % -->
                                                 <td class="px-0.5 pt-2 sm:pt-4 px-0.5 sm:px-4 text-right align-top">
                                                     <div class="w-10 sm:w-24 ml-auto">
-                                                        <div class="text-[10px] mb-0.5 sm:mb-1" x-text="(p.p_dnf * 100).toFixed(1) + '%'"></div>
+                                                        <div class="text-xs mb-0.5 sm:mb-1" x-text="(p.p_dnf * 100).toFixed(1) + '%'"></div>
                                                         <div class="progress-bar hidden sm:block" aria-hidden="true">
                                                             <div class="progress-fill" :style="'width: ' + (p.p_dnf * 100) + '%; background-color: ' + getProbColor(p.p_dnf * 100, true)"></div>
                                                         </div>
@@ -306,7 +306,7 @@
                                                         <!-- Model Mix bar -->
                                                         <template x-if="p.ensemble_components">
                                                             <div class="md:w-44 md:flex-shrink-0">
-                                                                <div class="text-[9px] font-bold text-gray-500 uppercase tracking-widest mb-0.5">Model Mix</div>
+                                                                <div class="text-xs font-bold text-gray-500 uppercase tracking-widest mb-0.5">Model Mix</div>
                                                                 <div class="flex items-center gap-0.5 h-2 rounded overflow-hidden w-36 sm:w-44" aria-hidden="true">
                                                                     <div class="h-full bg-cyan-500"   :style="'width:' + (p.ensemble_components.gbm   * 100).toFixed(1) + '%'" :title="'GBM '           + (p.ensemble_components.gbm   * 100).toFixed(0) + '%'"></div>
                                                                     <div class="h-full bg-yellow-400" :style="'width:' + (p.ensemble_components.elo   * 100).toFixed(1) + '%'" :title="'Elo '           + (p.ensemble_components.elo   * 100).toFixed(0) + '%'"></div>
@@ -314,22 +314,22 @@
                                                                     <div class="h-full bg-green-400"  :style="'width:' + (p.ensemble_components.mixed * 100).toFixed(1) + '%'" :title="'Mixed-Effects ' + (p.ensemble_components.mixed * 100).toFixed(0) + '%'"></div>
                                                                 </div>
                                                                 <div class="flex gap-2 mt-0.5 flex-wrap">
-                                                                    <span class="text-[9px] text-cyan-400"><span class="inline-block w-1.5 h-1.5 rounded-full bg-cyan-500 mr-0.5 align-middle"></span>GBM <span x-text="(p.ensemble_components.gbm * 100).toFixed(0) + '%'"></span></span>
-                                                                    <span class="text-[9px] text-yellow-400"><span class="inline-block w-1.5 h-1.5 rounded-full bg-yellow-400 mr-0.5 align-middle"></span>Elo <span x-text="(p.ensemble_components.elo * 100).toFixed(0) + '%'"></span></span>
-                                                                    <span class="text-[9px] text-purple-400"><span class="inline-block w-1.5 h-1.5 rounded-full bg-purple-500 mr-0.5 align-middle"></span>BT <span x-text="(p.ensemble_components.bt * 100).toFixed(0) + '%'"></span></span>
-                                                                    <span class="text-[9px] text-green-400"><span class="inline-block w-1.5 h-1.5 rounded-full bg-green-400 mr-0.5 align-middle"></span>Mix <span x-text="(p.ensemble_components.mixed * 100).toFixed(0) + '%'"></span></span>
+                                                                    <span class="text-xs text-cyan-400"><span class="inline-block w-1.5 h-1.5 rounded-full bg-cyan-500 mr-0.5 align-middle"></span>GBM <span x-text="(p.ensemble_components.gbm * 100).toFixed(0) + '%'"></span></span>
+                                                                    <span class="text-xs text-yellow-400"><span class="inline-block w-1.5 h-1.5 rounded-full bg-yellow-400 mr-0.5 align-middle"></span>Elo <span x-text="(p.ensemble_components.elo * 100).toFixed(0) + '%'"></span></span>
+                                                                    <span class="text-xs text-purple-400"><span class="inline-block w-1.5 h-1.5 rounded-full bg-purple-500 mr-0.5 align-middle"></span>BT <span x-text="(p.ensemble_components.bt * 100).toFixed(0) + '%'"></span></span>
+                                                                    <span class="text-xs text-green-400"><span class="inline-block w-1.5 h-1.5 rounded-full bg-green-400 mr-0.5 align-middle"></span>Mix <span x-text="(p.ensemble_components.mixed * 100).toFixed(0) + '%'"></span></span>
                                                                 </div>
                                                             </div>
                                                         </template>
                                                         <!-- SHAP factors -->
                                                         <template x-if="hasShapFactors(p.shap_values)">
                                                             <div class="min-w-0">
-                                                                <div class="text-[9px] font-bold text-gray-500 uppercase tracking-widest mb-0.5">
+                                                                <div class="text-xs font-bold text-gray-500 uppercase tracking-widest mb-0.5">
                                                                     Factors <span class="normal-case font-normal text-gray-600">(green = helps, red = hurts)</span>
                                                                 </div>
                                                                 <div class="flex flex-nowrap gap-x-2 gap-y-0.5 overflow-x-auto md:overflow-hidden no-scrollbar">
                                                                     <template x-for="feat in getSortedShap(p.shap_values, windowWidth)" :key="feat.key + '_' + windowWidth">
-                                                                        <div class="flex items-center flex-shrink-0 gap-1 text-[9px] w-[120px]">
+                                                                        <div class="flex items-center flex-shrink-0 gap-1 text-xs w-[140px]">
                                                                             <span class="sr-only" x-text="feat.val < 0 ? 'Improves position:' : 'Worsens position:'"></span>
                                                                             <span aria-hidden="true" :class="feat.val < 0 ? 'text-green-400' : 'text-red-400'" class="font-bold w-3 text-center" x-text="feat.val < 0 ? '▲' : '▼'"></span>
                                                                             <div class="w-8 h-1.5 bg-gray-700 rounded overflow-hidden flex-shrink-0" aria-hidden="true">
@@ -349,8 +349,8 @@
                                 </table>
 
                                 <div class="mt-3 rounded border border-gray-700 bg-gray-900/40 p-3">
-                                    <div class="text-[10px] font-bold uppercase tracking-widest text-gray-400 mb-2">Influence Legend</div>
-                                    <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-[11px] text-gray-300">
+                                    <div class="text-xs font-bold uppercase tracking-widest text-gray-400 mb-2">Influence Legend</div>
+                                    <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs text-gray-300">
                                         <div>
                                             <div class="font-semibold text-gray-200 mb-1">Model Mix (ensemble blend)</div>
                                             <div class="space-y-2">
@@ -381,8 +381,8 @@
                                         </div>
                                     </div>
                                     <details class="mt-3 border-t border-gray-700 pt-2">
-                                        <summary class="cursor-pointer text-[10px] font-bold uppercase tracking-widest text-gray-400 hover:text-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 rounded transition">Input Variable Glossary</summary>
-                                        <div class="mt-2 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-4 gap-y-1 text-[10px]">
+                                        <summary class="cursor-pointer text-xs font-bold uppercase tracking-widest text-gray-400 hover:text-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 rounded transition">Input Variable Glossary</summary>
+                                        <div class="mt-2 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-4 gap-y-1 text-xs">
                                             <template x-for="entry in getFeatureLegendEntries()" :key="entry.key">
                                                 <div class="flex justify-between gap-2 text-gray-300 border-b border-gray-800/60 pb-0.5">
                                                     <span class="truncate" x-text="entry.label"></span>
@@ -732,8 +732,8 @@
                     const offset = w >= 1024 ? 360 : 330;
                     const available = containerW - offset;
 
-                    // Fixed budget of 128px (120px item + 8px gap).
-                    const count = Math.floor(available / 128);
+                    // Fixed budget of 148px (140px item + 8px gap).
+                    const count = Math.floor(available / 148);
                     return Math.max(1, Math.min(20, count));
                 },
 


### PR DESCRIPTION
💡 **What**: Increased font sizes of very small elements (Model Mix, SHAP Factors, Legend, Glossary, weather info, and table headers) from hardcoded 9px, 10px, and 11px to Tailwind's standard `text-xs` (12px). Adjusted the SHAP factor item width from `120px` to `140px` and updated the `getFactorLimit()` responsive logic to use a larger budget (148px) per item.

🎯 **Why**: The previous font sizes were too small and inconsistent, leading to poor readability and a cluttered typographic scale. Standardizing to `text-xs` improves legibility and visual consistency across the application.

📸 **Before/After**: Verified via Playwright screenshots. Small labels are now clearly legible at 12px. The SHAP factors continue to fit correctly on desktop and scroll on mobile.

♻️ **Accessibility**: Improved readability for all users, especially those with visual impairments, by eliminating sub-12px font sizes. Encourages a more consistent and accessible typographic hierarchy.

Fixes #295

---
*PR created automatically by Jules for task [11367344092846007138](https://jules.google.com/task/11367344092846007138) started by @2fst4u*