### PR TITLE
🧹 Sweep: Prevent identical Monte Carlo outcomes across sessions

### DIFF
--- a/f1pred/predict.py
+++ b/f1pred/predict.py
@@ -527,11 +527,17 @@ def _run_single_prediction(
     
     # Monte Carlo simulation
     draws = cfg.modelling.monte_carlo.draws
+
+    # Calculate a unique but deterministic seed for this session
+    import hashlib
+    seed_str = f"{cfg.app.random_seed}_{season_i}_{round_i}_{sess}"
+    session_seed = int(hashlib.md5(seed_str.encode("utf-8")).hexdigest(), 16) % (2**32)
+
     prob_matrix, mean_pos, pairwise = simulate_grid(
         combined_pace,
         dnf_prob,
         draws=draws,
-        random_seed=cfg.app.random_seed,
+        random_seed=session_seed,
         noise_factor=cfg.modelling.simulation.noise_factor,
         min_noise=cfg.modelling.simulation.min_noise,
         max_penalty_base=cfg.modelling.simulation.max_penalty_base,
@@ -1028,11 +1034,17 @@ def run_predictions_for_event(
                         # Monte Carlo simulation
                         spinner.update("Simulating Monte Carlo...")
                         draws = cfg.modelling.monte_carlo.draws
+
+                        # Calculate a unique but deterministic seed for this session
+                        import hashlib
+                        seed_str = f"{cfg.app.random_seed}_{season_i}_{round_i}_{sess}"
+                        session_seed = int(hashlib.md5(seed_str.encode("utf-8")).hexdigest(), 16) % (2**32)
+
                         prob_matrix, mean_pos, pairwise = simulate_grid(
                             combined_pace,
                             dnf_prob,
                             draws=draws,
-                            random_seed=cfg.app.random_seed,
+                            random_seed=session_seed,
                             noise_factor=cfg.modelling.simulation.noise_factor,
                             min_noise=cfg.modelling.simulation.min_noise,
                             max_penalty_base=cfg.modelling.simulation.max_penalty_base,


### PR DESCRIPTION
💡 What
Modified `f1pred/predict.py` to calculate a dynamic, deterministic random seed for Monte Carlo `simulate_grid` calls rather than using the raw static `cfg.app.random_seed`.

🎯 Why
Previously, the static `cfg.app.random_seed` generated the exact same stochastic noise pattern and DNF distributions across all sessions in a round. If the features were heavily influenced by form indices (which is common early in a season or regulation cycle), the baseline GBM pace predictions were very similar, leading the Monte Carlo simulation to produce mathematically identical Win, Podium, and DNF probabilities. Hashing the session metadata (season, round, session type) guarantees independent, random, and reproducible stochastic variance for each session type.

🔬 Verification
1. Evaluated `python main.py --round next` locally. Confirmed distinct predictions between Sprint Qualifying, Sprint, Qualifying, and Race.
2. Evaluated test coverage by executing unit tests on `tests/test_models.py` and `tests/test_simulate.py`. All passing.
3. Code review completed without objections.

---
*PR created automatically by Jules for task [9811364385784789483](https://jules.google.com/task/9811364385784789483) started by @2fst4u*