### PR TITLE
🎨 Palette: Add cohesive hover state to prediction rows

### DIFF
--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -242,7 +242,7 @@
                                         </tr>
                                     </thead>
                                     <template x-for="(p, index) in data.predictions" :key="p.driverId">
-                                        <tbody class="border-none">
+                                        <tbody class="border-none hover:bg-white/5 transition-colors">
                                             <tr :class="getTeamClass(p.constructorName)" class="text-sm sm:text-base">
                                                 <!-- Position -->
                                                 <td class="px-0.5 pt-2 sm:pt-4 px-0.5 sm:px-4 text-center font-black italic text-base sm:text-lg align-top"


### PR DESCRIPTION
💡 What: Added `hover:bg-white/5 transition-colors` to the `<tbody class="border-none">` wrapping each individual prediction row and its associated details panel (Model Mix / Factors).
🎯 Why: Previously, because a single driver's prediction spans multiple `<tr>` tags (the main data row and the details row underneath), there was no cohesive hover state connecting them. Applying the hover state to the `<tbody>` solves this by grouping the entire block visually.
📸 Before/After: Verified via Playwright screenshot that hovering anywhere within the driver's prediction `<tbody>` block uniformly highlights both the main row and the influence details.
♿ Accessibility: Preserves keyboard accessibility and focus states. This is a purely visual enhancement to improve readability and tracking across complex data grids without altering semantic HTML.

---
*PR created automatically by Jules for task [18315654765458715869](https://jules.google.com/task/18315654765458715869) started by @2fst4u*