### PR TITLE
🎨 Palette: Align input factor graphs with model mix layout

### DIFF
--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -330,15 +330,15 @@
                                                                 </div>
                                                                 <div class="flex flex-nowrap gap-x-1 md:gap-x-4 gap-y-0.5 overflow-hidden no-scrollbar">
                                                                     <template x-for="feat in getSortedShap(p.shap_values, windowWidth)" :key="feat.key + '_' + windowWidth">
-                                                                        <div class="flex flex-col md:flex-row md:items-center flex-shrink-0 gap-0.5 md:gap-1 text-xs w-[115px] md:w-[140px]">
-                                                                            <span class="text-gray-400 truncate" x-text="feat.label" :title="feat.label"></span>
-                                                                            <div class="flex items-center gap-1">
+                                                                        <div class="flex flex-col flex-shrink-0 gap-0.5 text-xs w-[90px] md:w-[110px]">
+                                                                            <div class="flex items-center gap-1 h-2">
                                                                                 <span class="sr-only" x-text="feat.val < 0 ? 'Improves position:' : 'Worsens position:'"></span>
                                                                                 <span aria-hidden="true" :class="feat.val < 0 ? 'text-green-400' : 'text-red-400'" class="font-bold w-3 text-center" x-text="feat.val < 0 ? '▲' : '▼'"></span>
-                                                                                <div class="w-12 md:w-8 h-1.5 bg-gray-700 rounded overflow-hidden flex-shrink-0" aria-hidden="true">
+                                                                                <div class="w-10 md:w-12 h-2 bg-gray-700 rounded overflow-hidden flex-shrink-0" aria-hidden="true">
                                                                                     <div class="h-full rounded" :class="feat.val < 0 ? 'bg-green-500' : 'bg-red-500'" :style="'width:' + Math.min(100, feat.absPct).toFixed(0) + '%'"></div>
                                                                                 </div>
                                                                             </div>
+                                                                            <span class="text-gray-400 truncate" x-text="feat.label" :title="feat.label"></span>
                                                                         </div>
                                                                     </template>
                                                                 </div>
@@ -804,7 +804,7 @@
                     const w = this.windowWidth || window.innerWidth;
                     const containerW = Math.min(w, 1400);
                     // Mobile should only show as many as can fit
-                    if (w < 768) return Math.floor((w - 32) / 119);
+                    if (w < 768) return Math.floor((w - 32) / 94);
 
                     // Sidebar (w-64 = 256px) is side-by-side at >= 768px (md breakpoint).
                     // sidebar(256) + gap(16) = 272 (was gap-x-8 = 32px)
@@ -812,8 +812,8 @@
                     const offset = w >= 1024 ? 380 : 350;
                     const available = containerW - offset;
 
-                    // Fixed budget of 156px (140px item + 16px gap).
-                    const count = Math.floor(available / 156);
+                    // Fixed budget of 126px (110px item + 16px gap).
+                    const count = Math.floor(available / 126);
                     return Math.max(1, Math.min(20, count));
                 },
 

--- a/tests/test_ui_layout.py
+++ b/tests/test_ui_layout.py
@@ -71,20 +71,20 @@ def test_model_mix_width_and_offsets(page: "Page"):
     page.evaluate("Alpine.$data(document.querySelector('[x-data]')).windowWidth = 1200")
     limit_large = page.evaluate("Alpine.$data(document.querySelector('[x-data]')).getFactorLimit()")
     # Expected for 1200px: w >= 1024 -> offset = 380. containerW = 1200.
-    # available = 1200 - 380 = 820. count = floor(820 / 156) = 5.
-    assert limit_large == 5
+    # available = 1200 - 380 = 820. count = floor(820 / 126) = 6.
+    assert limit_large == 6
 
     # Test Desktop (Medium Viewport)
     page.set_viewport_size({"width": 800, "height": 800})
     page.evaluate("Alpine.$data(document.querySelector('[x-data]')).windowWidth = 800")
     limit_medium = page.evaluate("Alpine.$data(document.querySelector('[x-data]')).getFactorLimit()")
     # Expected for 800px: w < 1024 -> offset = 350. containerW = 800.
-    # available = 800 - 350 = 450. count = floor(450 / 156) = 2.
-    assert limit_medium == 2
+    # available = 800 - 350 = 450. count = floor(450 / 126) = 3.
+    assert limit_medium == 3
 
     # Test Mobile
     page.set_viewport_size({"width": 400, "height": 800})
     page.evaluate("Alpine.$data(document.querySelector('[x-data]')).windowWidth = 400")
     limit_mobile = page.evaluate("Alpine.$data(document.querySelector('[x-data]')).getFactorLimit()")
-    # Expected for 400px: w < 768 -> floor((400 - 32) / 119) = floor(368 / 119) = 3.
+    # Expected for 400px: w < 768 -> floor((400 - 32) / 94) = floor(368 / 94) = 3.
     assert limit_mobile == 3


### PR DESCRIPTION
💡 What: Reordered and standardized the layout of the 'Factors' (input variable strength) section to match the 'Model Mix' section. Specifically, the factor graphs now sit directly above their text labels, and all elements use a consistent vertical structure and height (h-2).

🎯 Why: This change creates a more cohesive visual hierarchy where both types of influence graphs (ensemble components and ML features) are displayed identically. Moving labels below graphs also reclaims horizontal space, allowing more factors to be visible at once without scrolling.

📸 Before/After: 
- Before: Factors were 'Label [Graph]', wide (115-140px), and slightly misaligned vertically with Model Mix.
- After: Factors are '[Graph]\nLabel', narrow (90-110px), and perfectly aligned with the Model Mix section's Heading/Graph/Label stack.

♿ Accessibility: Maintained `aria-hidden` on decorative graphs and utilized `sr-only` spans for directional context ('Improves position' vs 'Worsens position'). Labels remain truncated with full titles available on hover for screen readers and mouse users.

Fixes #310

---
*PR created automatically by Jules for task [6829161433490004173](https://jules.google.com/task/6829161433490004173) started by @2fst4u*