### PR TITLE
🧪 Spec: Add PredictionManager test coverage

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -1,0 +1,6 @@
+
+### Mocking local imports
+When attempting to mock functions that are locally imported within a method's body (like `from .predict import run_predictions_for_event` inside `PredictionManager._run_prediction_cycle()`), attempting to patch the calling module's namespace (e.g. `f1pred.prediction_manager.run_predictions_for_event`) will fail with an AttributeError because the function doesn't exist on the module level. You must patch the original module where the function resides (e.g., `@patch('f1pred.predict.run_predictions_for_event')`).
+
+### Avoiding application logic changes for tests
+When an application's data transformations (e.g., rounding) crash on `None` values (like `math.isnan`), do not alter the application code to handle the `None` just so a test can assert how it behaves. Instead, write tests that pass valid types or verify the exception is handled upstream if that is the intended behavior.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,6 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 63.74
+fail_under = 65.80
 show_missing = true
 precision = 2

--- a/tests/test_prediction_manager.py
+++ b/tests/test_prediction_manager.py
@@ -227,3 +227,267 @@ class TestPredictionManagerLifecycle:
         received = q.get_nowait()
         assert received["type"] == "test"
         assert received["message"] == "hello"
+
+class TestPredictionManagerCycle:
+    def test_run_prediction_cycle_success(self):
+        cfg = MagicMock()
+        cfg.data_sources.jolpica.base_url = "https://api.example.com"
+        cfg.data_sources.jolpica.timeout_seconds = 10
+        cfg.data_sources.jolpica.rate_limit_sleep = 0.5
+        cfg.modelling.targets.session_types = ["qualifying", "race"]
+
+        manager = PredictionManager(cfg, poll_interval=60)
+
+        import pandas as pd
+        df = pd.DataFrame([{
+            "driverId": "ver01",
+            "predicted_position": 1,
+            "code": "VER",
+            "name": "Max Verstappen",
+            "constructorName": "Red Bull",
+            "p_win": 0.9,
+            "p_top3": 0.99,
+            "mean_pos": 1.1,
+            "grid": 1
+        }])
+
+        fake_results = {
+            "season": 2024,
+            "round": 1,
+            "sessions": {
+                "race": {
+                    "ranked": df,
+                    "meta": {"weather": {"temp_mean": 25.0}}
+                }
+            }
+        }
+
+        with patch('f1pred.predict.resolve_event') as mock_resolve:
+            with patch('f1pred.predict.run_predictions_for_event') as mock_predict:
+                with patch('f1pred.data.jolpica.JolpicaClient') as mock_jc:
+                    mock_resolve.return_value = (2024, 1, {"raceName": "Bahrain Grand Prix"})
+                    mock_predict.return_value = fake_results
+
+                    manager._run_prediction_cycle()
+
+        assert manager.status == "idle"
+        assert manager.latest_results is not None
+        assert manager.latest_results["season"] == 2024
+        assert "race" in manager.latest_results["sessions"]
+
+    def test_run_prediction_cycle_resolve_fails(self):
+        cfg = MagicMock()
+        cfg.data_sources.jolpica.base_url = "https://api.example.com"
+        cfg.data_sources.jolpica.timeout_seconds = 10
+        cfg.data_sources.jolpica.rate_limit_sleep = 0.5
+        manager = PredictionManager(cfg, poll_interval=60)
+
+        with patch('f1pred.predict.resolve_event') as mock_resolve:
+            with patch('f1pred.data.jolpica.JolpicaClient') as mock_jc:
+                mock_resolve.side_effect = Exception("API error")
+
+                manager._run_prediction_cycle()
+
+        assert manager.status == "error"
+
+    def test_run_prediction_cycle_no_results(self):
+        cfg = MagicMock()
+        cfg.data_sources.jolpica.base_url = "https://api.example.com"
+        cfg.data_sources.jolpica.timeout_seconds = 10
+        cfg.data_sources.jolpica.rate_limit_sleep = 0.5
+        cfg.modelling.targets.session_types = ["qualifying", "race"]
+        manager = PredictionManager(cfg, poll_interval=60)
+
+        with patch('f1pred.predict.resolve_event') as mock_resolve:
+            with patch('f1pred.predict.run_predictions_for_event') as mock_predict:
+                with patch('f1pred.data.jolpica.JolpicaClient') as mock_jc:
+                    mock_resolve.return_value = (2024, 1, {"raceName": "Bahrain Grand Prix"})
+                    mock_predict.return_value = None
+
+                    manager._run_prediction_cycle()
+
+        assert manager.status == "idle"
+        assert manager.latest_results is None
+
+    def test_run_prediction_cycle_with_sprint(self):
+        cfg = MagicMock()
+        cfg.data_sources.jolpica.base_url = "https://api.example.com"
+        cfg.data_sources.jolpica.timeout_seconds = 10
+        cfg.data_sources.jolpica.rate_limit_sleep = 0.5
+        cfg.modelling.targets.session_types = ["qualifying", "race", "sprint", "sprint_qualifying"]
+
+        manager = PredictionManager(cfg, poll_interval=60)
+
+        import pandas as pd
+        df = pd.DataFrame([{
+            "driverId": "ver01",
+            "predicted_position": 1,
+            "grid": 1
+        }])
+
+        fake_results = {
+            "season": 2024,
+            "round": 1,
+            "sessions": {
+                "race": {"ranked": df, "meta": {}},
+                "sprint": {"ranked": df, "meta": {}}
+            }
+        }
+
+        with patch('f1pred.predict.resolve_event') as mock_resolve:
+            with patch('f1pred.predict.run_predictions_for_event') as mock_predict:
+                with patch('f1pred.data.jolpica.JolpicaClient') as mock_jc:
+                    mock_resolve.return_value = (2024, 1, {"raceName": "Bahrain Grand Prix", "Sprint": {}, "SprintQualifying": {}})
+                    mock_predict.return_value = fake_results
+
+                    manager._run_prediction_cycle()
+
+        requested_sessions = mock_predict.call_args[1]["sessions"]
+        assert "sprint" in requested_sessions
+        assert "sprint_qualifying" in requested_sessions
+
+
+    def test_run_prediction_cycle_with_diffs(self):
+        from f1pred.prediction_manager import PredictionManager
+        import pandas as pd
+
+        cfg = MagicMock()
+        cfg.data_sources.jolpica.base_url = "https://api.example.com"
+        cfg.data_sources.jolpica.timeout_seconds = 10
+        cfg.data_sources.jolpica.rate_limit_sleep = 0.5
+        cfg.modelling.targets.session_types = ["qualifying", "race"]
+
+        manager = PredictionManager(cfg, poll_interval=60)
+
+        # Setup initial state
+        df1 = pd.DataFrame([{
+            "driverId": "ver01",
+            "predicted_position": 1,
+            "code": "VER",
+            "name": "Max Verstappen",
+            "constructorName": "Red Bull",
+            "p_win": 0.9,
+            "p_top3": 0.99,
+            "mean_pos": 1.1,
+            "grid": 1
+        }, {
+            "driverId": "ham44",
+            "predicted_position": 2,
+            "code": "HAM",
+            "name": "Lewis Hamilton",
+            "constructorName": "Mercedes",
+            "p_win": 0.1,
+            "p_top3": 0.5,
+            "mean_pos": 2.1,
+            "grid": 2
+        }])
+
+        fake_results1 = {
+            "season": 2024,
+            "round": 1,
+            "sessions": {
+                "race": {
+                    "ranked": df1,
+                    "meta": {"weather": {"temp_mean": 25.0}}
+                }
+            }
+        }
+
+        with patch('f1pred.predict.resolve_event') as mock_resolve:
+            with patch('f1pred.predict.run_predictions_for_event') as mock_predict:
+                with patch('f1pred.data.jolpica.JolpicaClient') as mock_jc:
+                    mock_resolve.return_value = (2024, 1, {"raceName": "Bahrain Grand Prix"})
+                    mock_predict.return_value = fake_results1
+
+                    manager._run_prediction_cycle()
+
+        assert manager.latest_results is not None
+        assert len(manager.latest_diffs) == 0
+
+        # Now change the results to trigger a diff
+        df2 = pd.DataFrame([{
+            "driverId": "ham44",
+            "predicted_position": 1,
+            "code": "HAM",
+            "name": "Lewis Hamilton",
+            "constructorName": "Mercedes",
+            "p_win": 0.6,
+            "p_top3": 0.9,
+            "mean_pos": 1.2,
+            "grid": 1
+        }, {
+            "driverId": "ver01",
+            "predicted_position": 2,
+            "code": "VER",
+            "name": "Max Verstappen",
+            "constructorName": "Red Bull",
+            "p_win": 0.4,
+            "p_top3": 0.8,
+            "mean_pos": 1.8,
+            "grid": 2
+        }])
+
+        fake_results2 = {
+            "season": 2024,
+            "round": 1,
+            "sessions": {
+                "race": {
+                    "ranked": df2,
+                    "meta": {"weather": {"temp_mean": 30.0}}
+                }
+            }
+        }
+
+        with patch('f1pred.predict.resolve_event') as mock_resolve:
+            with patch('f1pred.predict.run_predictions_for_event') as mock_predict:
+                with patch('f1pred.data.jolpica.JolpicaClient') as mock_jc:
+                    mock_resolve.return_value = (2024, 1, {"raceName": "Bahrain Grand Prix"})
+                    mock_predict.return_value = fake_results2
+
+                    manager._run_prediction_cycle()
+
+        assert manager.latest_results is not None
+        assert len(manager.latest_diffs) > 0
+        diff = manager.latest_diffs[-1]
+        assert diff["session"] == "race"
+        assert len(diff["movements"]) == 2
+        assert "Grid positions changed" in diff["changed_variables"]
+
+    def test_run_loop(self):
+        from f1pred.prediction_manager import PredictionManager
+        import threading
+        import time
+
+        cfg = MagicMock()
+        manager = PredictionManager(cfg, poll_interval=1)
+
+        # Patch the actual sleep so we don't wait 5s
+        with patch('time.sleep') as mock_sleep:
+            # Patch the cycle to stop the loop after one iteration
+            with patch.object(manager, '_run_prediction_cycle') as mock_cycle:
+                def side_effect():
+                    manager._running = False
+                mock_cycle.side_effect = side_effect
+
+                manager._running = True
+                manager._run_loop()
+
+                assert mock_cycle.called
+
+    def test_run_loop_exception(self):
+        from f1pred.prediction_manager import PredictionManager
+
+        cfg = MagicMock()
+        manager = PredictionManager(cfg, poll_interval=1)
+
+        with patch('time.sleep'):
+            with patch.object(manager, '_run_prediction_cycle') as mock_cycle:
+                def side_effect():
+                    manager._running = False
+                    raise Exception("Test error")
+                mock_cycle.side_effect = side_effect
+
+                manager._running = True
+                manager._run_loop()
+
+                assert manager.status == "error"


### PR DESCRIPTION
💡 What: Added comprehensive tests for `PredictionManager._run_prediction_cycle()`. Included tests for successful cycles, resolution failures, instances with no results, and sprint session handling.
🎯 Why: `f1pred/prediction_manager.py` had low test coverage (missing ~124 lines), specifically leaving the core background polling cycle completely unverified. 
📈 Maturity Impact: Bumped overall coverage threshold from 63.74% to 65.80% to lock in progress toward business standards.

---
*PR created automatically by Jules for task [5885380555289768874](https://jules.google.com/task/5885380555289768874) started by @2fst4u*