### PR TITLE
🧪 Spec: Fix F1 Outcome Predictor string match in test_read_main

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -15,7 +15,7 @@ def client():
 def test_read_main(client):
     response = client.get("/")
     assert response.status_code == 200
-    assert "F1 OUTCOME PREDICTOR" in response.text
+    assert "<title>F1 Outcome Predictor</title>" in response.text
 
 def test_get_config(client):
     response = client.get("/api/config")


### PR DESCRIPTION
💡 What: Updated `test_read_main` to check for `<title>F1 Outcome Predictor</title>` instead of an exact uppercase string.
🎯 Why: The original test was failing due to casing differences in the actual UI template, causing CI to break. Checking against the `<title>` tag is structurally robust and resilient to body text changes.
📈 Maturity Impact: Fixed the immediate CI failure block without dropping test coverage.

---
*PR created automatically by Jules for task [9654421248971492153](https://jules.google.com/task/9654421248971492153) started by @2fst4u*