### PR TITLE
📚 Archivist: Fix cache clearing instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ f1pred/
 Clear the cache and re-run:
 
 ```bash
-rm -rf cache/ fastf1_cache/ .cache/
+rm -rf cache/ .cache/
 python main.py --round next
 ```
 


### PR DESCRIPTION
💡 Problem: The README instructions for clearing the cache incorrectly told users to run `rm -rf cache/ fastf1_cache/ .cache/`. The `fastf1_cache/` directory does not exist at the project root; it is managed as a subdirectory of the main `cache_dir` configuration (`cache/fastf1/`). This creates confusion and phantom errors.

🎯 Fix: Removed the `fastf1_cache/` path from the README's `rm -rf` command, updating it to correctly reflect the actual cache locations (`cache/` and `.cache/`).

🧪 Verification: Verified `f1pred/config.py` and codebase references to confirm the FastF1 cache path is constructed dynamically as `Path(self.cache_dir) / "fastf1"`.

🔎 Scope: This PR contains ONLY documentation changes.

---
*PR created automatically by Jules for task [8190385578509830845](https://jules.google.com/task/8190385578509830845) started by @2fst4u*