### PR TITLE
Fix roster derivation session priority

### DIFF
--- a/f1pred/roster.py
+++ b/f1pred/roster.py
@@ -44,14 +44,8 @@ def _entries_from_results(results: List[Dict]) -> List[Dict]:
 def _same_round_known_roster(jc: JolpicaClient, season: str, rnd: str) -> List[Dict]:
     """
     Try to get the event roster from the same round, in order:
-      qualifying -> race -> sprint.
+      race -> sprint -> qualifying.
     """
-    try:
-        q = jc.get_qualifying_results(season, rnd)
-        if q:
-            return _entries_from_results(q)
-    except Exception:
-        pass
     try:
         r = jc.get_race_results(season, rnd)
         if r:
@@ -62,6 +56,12 @@ def _same_round_known_roster(jc: JolpicaClient, season: str, rnd: str) -> List[D
         s = jc.get_sprint_results(season, rnd)
         if s:
             return _entries_from_results(s)
+    except Exception:
+        pass
+    try:
+        q = jc.get_qualifying_results(season, rnd)
+        if q:
+            return _entries_from_results(q)
     except Exception:
         pass
     return []
@@ -231,8 +231,8 @@ def _roster_from_fastf1(season: int, rnd: int, mapping: Optional[Dict] = None) -
 
         # Try to load a session to get the roster.
         # We try multiple sessions in case some data is missing or hasn't occurred yet.
-        # Order: FP1 (standard), then sessions that might have occurred.
-        session_names = ["FP1", "Sprint Qualifying", "Sprint Shootout", "Qualifying", "Sprint", "Race"]
+        # Order: Prefer Race, then Sprint, then Qualifying, then Practice.
+        session_names = ["Race", "Sprint", "Qualifying", "Sprint Qualifying", "Sprint Shootout", "FP3", "FP2", "FP1"]
         results = None
 
         for sname in session_names:

--- a/tests/test_roster_fix.py
+++ b/tests/test_roster_fix.py
@@ -1,0 +1,72 @@
+import pytest
+import pandas as pd
+from unittest.mock import Mock, patch
+from datetime import datetime, timezone
+from f1pred.roster import derive_roster
+
+def test_roster_derivation_prefers_later_sessions():
+    """
+    Reproduce the issue where FP1 roster is picked even if Qualifying results are available.
+    In 2026 Japan GP, Jack Crawford did FP1 but Fernando Alonso did Qualifying and Race.
+    """
+    jc = Mock()
+    # Ensure Jolpica returns nothing for the current round to reach FastF1 logic
+    jc.get_qualifying_results.return_value = []
+    jc.get_race_results.return_value = []
+    jc.get_sprint_results.return_value = []
+    jc.get_season_entry_list.return_value = []
+    jc.get_latest_season_and_round.return_value = ("2025", "22")
+
+    # Mock FastF1 event and sessions
+    mock_event = Mock()
+
+    # Mock FP1 session
+    fp1_session = Mock()
+    fp1_session.results = pd.DataFrame([
+        {
+            "Abbreviation": "CRA",
+            "DriverNumber": "31",
+            "FirstName": "Jack",
+            "LastName": "Crawford",
+            "TeamName": "Aston Martin"
+        }
+    ])
+
+    # Mock Qualifying session
+    quali_session = Mock()
+    quali_session.results = pd.DataFrame([
+        {
+            "Abbreviation": "ALO",
+            "DriverNumber": "14",
+            "FirstName": "Fernando",
+            "LastName": "Alonso",
+            "TeamName": "Aston Martin"
+        }
+    ])
+
+    def get_session_mock(name):
+        if name == "FP1":
+            return fp1_session
+        if name == "Qualifying":
+            return quali_session
+        # Return empty session for others
+        s = Mock()
+        s.results = pd.DataFrame()
+        return s
+
+    mock_event.get_session.side_effect = get_session_mock
+
+    with patch("f1pred.data.fastf1_backend.get_event", return_value=mock_event):
+        # We need to mock _get_canonical_mapping to return something that won't fail
+        # Or just let it return empty dict, and it will use Abbreviations.
+
+        roster = derive_roster(jc, "2026", "4")
+
+        # Currently, it picks FP1 first because it iterates ["FP1", "Qualifying", ...]
+        # and breaks at the first hit.
+        driver_ids = [d["driverId"] for d in roster]
+
+        # REPRODUCTION: This assertion currently fails if we expect ALO, but passes if we got CRA
+        # The user says Jack Crawford (CRA) was incorrectly derived.
+        assert "alo" in driver_ids
+        assert "cra" not in driver_ids


### PR DESCRIPTION
This change fixes a roster derivation issue where drivers participating only in FP1 were incorrectly being included in the race roster even if the regular driver participated in later sessions like Qualifying.

Key changes:
- In `f1pred/roster.py`:
    - Updated `_same_round_known_roster` (Jolpica) to prefer results from race -> sprint -> qualifying.
    - Updated `_roster_from_fastf1` to prefer sessions in order: Race, Sprint, Qualifying, Sprint Qualifying, Sprint Shootout, FP3, FP2, FP1.
- Added `tests/test_roster_fix.py` to reproduce the issue and verify the fix.
- Verified that all existing roster-related tests pass.

Fixes #330

---
*PR created automatically by Jules for task [6470498711001037749](https://jules.google.com/task/6470498711001037749) started by @2fst4u*