### PR TITLE
🎨 Palette: Add keyboard navigation to scrollable containers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-05-19 - Empty State Directional Animation Cues
 **Learning:** Empty states that simply instruct a user to take an action (e.g., "Select a round") can leave users scanning the interface to locate the necessary control. Using a subtle, continuous directional animation (like an `animate-bounce` on an upward-pointing arrow) paired with explicit directional language ("Select a round above") provides immediate, intuitive micro-UX that guides the user's eye directly to the required input area, eliminating cognitive load.
 **Action:** When designing an empty state that relies on an input located elsewhere on the page, use animated directional icons and explicit positional phrasing in the helper text to explicitly guide the user's visual flow toward the required action.
+
+## 2024-05-19 - Keyboard Accessibility for Scrollable Containers
+**Learning:** Scrollable areas utilizing `overflow-x-auto` or `overflow-y-auto` cannot be scrolled via the keyboard (arrow keys) unless the container itself is able to receive focus. Adding `tabindex="0"`, `role="region"`, a descriptive `aria-label`, and visual focus indicators (`focus:outline-none focus-visible:ring-2`) directly to the overflowing container ensures complete accessibility for keyboard and screen reader users.
+**Action:** When designing scrollable regions (such as long tables or lists within tight viewports), always add `tabindex="0"`, `role="region"`, an appropriate `aria-label`, and `focus-visible:` styles to the wrapper element controlling the overflow.

--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -185,7 +185,7 @@
 
                     <div>
                         <div id="round-label" class="block text-xs font-bold text-gray-400 mb-2 uppercase tracking-wider">Round (Auto-Predicted)</div>
-                        <div role="group" aria-labelledby="round-label" class="flex space-x-2 overflow-x-auto no-scrollbar pb-2" :class="{'opacity-50 pointer-events-none': scheduleLoading}">
+                        <div role="group" aria-labelledby="round-label" tabindex="0" class="flex space-x-2 overflow-x-auto no-scrollbar pb-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded" :class="{'opacity-50 pointer-events-none': scheduleLoading}">
                             <template x-if="scheduleLoading">
                                 <span class="flex items-center text-xs text-gray-500 italic mt-1.5 pt-1">
                                     <i class="fas fa-circle-notch fa-spin mr-1.5" aria-hidden="true"></i>Loading schedule...
@@ -229,8 +229,8 @@
                         <h3 class="text-xs font-bold uppercase tracking-widest text-gray-400">Prediction Progress</h3>
                         <span class="ml-2 text-[10px] text-gray-500 italic" x-text="'(Processing Round ' + params.round + ')'"></span>
                     </summary>
-                    <div class="bg-black bg-opacity-30 rounded p-3 font-mono text-xs h-32 overflow-y-auto space-y-1"
-                        id="log-container" aria-live="polite">
+                    <div class="bg-black bg-opacity-30 rounded p-3 font-mono text-xs h-32 overflow-y-auto space-y-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                        id="log-container" aria-live="polite" tabindex="0" role="region" aria-label="Prediction Progress Logs">
                         <template x-for="log in logs">
                             <div class="flex">
                                 <span class="text-blue-500 mr-2" aria-hidden="true">></span>
@@ -259,7 +259,7 @@
                             <span class="ml-2 text-xs bg-green-600 text-white px-1.5 py-0.5 rounded-full"
                                 x-text="filteredRecentChanges().length"></span>
                         </summary>
-                        <div class="space-y-2 max-h-48 overflow-y-auto">
+                        <div class="space-y-2 max-h-48 overflow-y-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500 rounded" tabindex="0" role="region" aria-label="Recent Position Changes List">
                             <template x-for="(change, ci) in filteredRecentChanges()" :key="ci">
                                 <div class="bg-black bg-opacity-30 rounded p-2 text-sm flex items-center gap-3">
                                     <span class="text-xs text-gray-500 font-mono w-14 flex-shrink-0"
@@ -304,9 +304,9 @@
                 </div>
 
                 <!-- Session Tabs -->
-                <div class="flex border-b border-gray-700 mb-6 overflow-x-auto" role="tablist"
+                <div class="flex border-b border-gray-700 mb-6 overflow-x-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded-lg" role="tablist"
                     x-show="getAvailableSessions().length > 1"
-                    aria-label="Session Results">
+                    aria-label="Session Results" tabindex="0">
                     <template x-for="sess in getAvailableSessions()" :key="sess">
                         <button @click="activeSession = sess" role="tab"
                             :aria-selected="(activeSession === sess).toString()" :id="'tab-' + sess"


### PR DESCRIPTION
**💡 What:** Added `tabindex="0"`, `role="region"`, `aria-label`, and visual focus indicators (`focus-visible:ring-2`) to horizontally and vertically scrollable containers (Round selection buttons, Session Tabs, Prediction Progress logs, and Recent Position Changes list) in `index.html`.

**🎯 Why:** Without focusable elements, scrollable areas (`overflow-x-auto`, `overflow-y-auto`) cannot be scrolled using a keyboard (e.g., arrow keys). This prevents keyboard-only users from accessing content hidden by overflow. 

**📸 Before/After:** N/A (Visuals remain mostly unchanged unless a keyboard user tabs into the container, at which point a subtle ring indicator appears).

**♿ Accessibility:**
- Keyboard users can now Tab into these regions and use their arrow keys to scroll them horizontally or vertically.
- The use of `focus-visible` ensures that mouse/touch users are not disrupted by permanent or accidental focus rings when interacting with the regions.
- Screen readers will now explicitly announce these areas as regions with descriptive labels when receiving focus, providing necessary context.

---
*PR created automatically by Jules for task [8254770441200714287](https://jules.google.com/task/8254770441200714287) started by @2fst4u*