### PR TITLE
📚 Archivist: Fix cache directory references and test setup instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,4 @@ clean:
 	find . -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true
 	find . -type d -name .mypy_cache -exec rm -rf {} + 2>/dev/null || true
 	find . -type f -name '*.pyc' -delete
-	rm -rf .cache/
+	rm -rf cache/

--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ Run the local test suite (requires installing test dependencies first):
 
 ```bash
 make install
-pip install pytest pytest-cov httpx playwright fastparquet pyarrow colorama
+pip install pytest pytest-cov httpx pytest-playwright playwright fastparquet pyarrow colorama
+playwright install --with-deps chromium
 make test
 ```
 
@@ -201,7 +202,7 @@ f1pred/
 Clear the cache and re-run:
 
 ```bash
-rm -rf cache/ .cache/
+rm -rf cache/
 python main.py --round next
 ```
 
@@ -209,7 +210,7 @@ python main.py --round next
 Enable FastF1 in `config.yaml`.
 
 **Rate limiting errors?**
-The built-in cache and retry logic should handle most cases. Try increasing `live_refresh_seconds` or clearing the `.cache/` directory.
+The built-in cache and retry logic should handle most cases. Try increasing `live_refresh_seconds` or clearing the `cache/` directory.
 
 **Import errors for LightGBM on macOS?**
 


### PR DESCRIPTION
💡 Problem: The README.md and Makefile referenced an outdated `.cache/` directory instead of the actual `cache/` directory defined in config.yaml. Additionally, the test setup instructions in README.md were missing required dependencies (`pytest-playwright` and `playwright install`) leading to failed test runs for new contributors.

🎯 Fix: Unified the cache directory references to `cache/` across README.md and Makefile. Added the missing Playwright dependencies to the testing instructions in README.md.

🧪 Verification: Executed `make test` successfully after updating the instructions and verifying tests pass. Verified `cache/` is the active directory in config.yaml.

🔎 Scope: Only modified documentation (README.md) and script automation metadata (Makefile). No application code or product behavior was changed.

---
*PR created automatically by Jules for task [1586644718251329244](https://jules.google.com/task/1586644718251329244) started by @2fst4u*