### PR TITLE
🧹 Sweep: Remove unused compute_driver_team_form function

### DIFF
--- a/f1pred/features.py
+++ b/f1pred/features.py
@@ -728,53 +728,6 @@ def compute_circuit_proficiency(df: pd.DataFrame, circuit_id: str, ref_date: dat
     return metrics
 
 
-def compute_driver_team_form(
-    df: pd.DataFrame,
-    roster: pd.DataFrame,
-    ref_date: datetime,
-    half_life_days: int,
-    window_days: int = 730,
-    current_season: Optional[int] = None,
-    boost_factor: float = 1.0,
-) -> pd.DataFrame:
-    """Driver-team specific form for current constructor."""
-    if df.empty or roster.empty:
-        return pd.DataFrame(columns=["driverId", "driver_team_form_index", "team_tenure_events"])
-
-    min_dt = ref_date - timedelta(days=window_days)
-    races = df[(df["session"] == "race") & (df["date"] >= min_dt)].copy()
-    races = races.dropna(subset=["driverId", "constructorId", "date"])
-
-    cur_map = roster.set_index("driverId")["constructorId"].to_dict()
-    races["cur_constructor"] = races["driverId"].map(cur_map)
-    races = races[races["constructorId"] == races["cur_constructor"]].copy()
-    if races.empty:
-        return pd.DataFrame(columns=["driverId", "driver_team_form_index", "team_tenure_events"])
-
-    races["pos_score"] = -races["position"].astype(float).fillna(0.0)
-    races["pts_score"] = races["points"].astype(float).fillna(0.0)
-    w = exponential_weights(races["date"], ref_date, half_life_days)
-    if current_season is not None and boost_factor != 1.0 and "season" in races.columns:
-        w = np.where(races["season"] == current_season, w * boost_factor, w)
-    races["w"] = w
-
-    races["weighted_val"] = (races["pos_score"] + races["pts_score"]) * races["w"]
-    races = races.dropna(subset=["driverId"])
-
-    driver_codes, uniques = pd.factorize(races["driverId"])
-    w_sum = np.bincount(driver_codes, weights=races["w"])
-    val_sum = np.bincount(driver_codes, weights=races["weighted_val"])
-    events_count = np.bincount(driver_codes)
-
-    agg = pd.DataFrame({
-        "driverId": uniques,
-        "driver_team_form_index": val_sum / np.clip(w_sum, 1e-6, None),
-        "team_tenure_events": events_count
-    })
-
-    return agg
-
-
 def compute_teammate_delta(
     hist: pd.DataFrame,
     ref_date: datetime,

--- a/f1pred/predict.py
+++ b/f1pred/predict.py
@@ -1334,7 +1334,6 @@ _FEATURE_LABELS: Dict[str, str] = {
     "weather_wind_mean":         "Wind Speed",
     "weather_pressure_mean":     "Air Pressure",
     "weather_humidity_mean":     "Humidity",
-    "team_tenure_events":        "Team Tenure",
     "is_race":                   "Race Session",
     "is_qualifying":             "Quali Session",
     "is_sprint":                 "Sprint Session",

--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -1469,7 +1469,6 @@
                 _featureLabels: {
                     form_index: 'Race Form',
                     qualifying_form_index: 'Quali Form',
-                    driver_team_form_index: 'Driver-Team Fit',
                     team_form_index: 'Team Strength',
                     teammate_delta: 'vs Teammate',
                     grid_finish_delta: 'Overtaking Skill',
@@ -1494,7 +1493,6 @@
                     weather_wind_mean: 'Wind Speed',
                     weather_pressure_mean: 'Air Pressure',
                     weather_humidity_mean: 'Humidity',
-                    team_tenure_events: 'Team Tenure',
                     is_race: 'Race Session',
                     is_qualifying: 'Quali Session',
                     is_sprint: 'Sprint Session',


### PR DESCRIPTION
💡 What: Removed the unused `compute_driver_team_form` function from `f1pred/features.py` and its corresponding label entries in `f1pred/predict.py` and `f1pred/templates/index.html`.
🎯 Why: This function is not executed or imported anywhere in the project, acting as dead code. Removing it reduces repository bloat and simplifies the feature space.
🔬 Verification: Ran `git grep -rn "compute_driver_team_form"` to confirm there are no references left across the codebase. Test suite ran successfully via `make test` confirming zero application logic changes.

---
*PR created automatically by Jules for task [11134559682632424746](https://jules.google.com/task/11134559682632424746) started by @2fst4u*