### PR TITLE
📚 Archivist: Fix Missing Playwright Dependency Command in README

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -3,8 +3,8 @@
 **Action:** When auditing configuration options, cross-reference `config.yaml` values explicitly against the `README.md` to spot undocumented parameters (like `precipitation_unit`).
 
 ## 2024-03-10 - Test Dependency Drift
-**Learning:** The development environment requires manual installation of test and runtime tools (`playwright`, `fastparquet`, `pyarrow`, `colorama`) beyond the base dependencies in `requirements.txt`. The `README.md` instructions frequently drift from the actual required sequence.
-**Action:** When updating test instructions, ensure the sequence explicitly includes `make install` followed by the manual installation of all test dependencies before running `make test`.
+**Learning:** The development environment requires manual installation of test and runtime tools (`playwright`, `fastparquet`, `pyarrow`, `colorama`) beyond the base dependencies in `requirements.txt`. The `README.md` instructions frequently drift from the actual required sequence, specifically omitting the browser binary installation required by `pytest-playwright`.
+**Action:** When updating test instructions, ensure the sequence explicitly includes `make install` followed by the manual installation of all test dependencies (including `playwright install --with-deps chromium`) before running `make test`.
 
 ## 2026-03-22 - Variable Glossary Drift
 **Learning:** Model features and their internal keys (`form_index`, `teammate_delta`, etc.) frequently evolve in `f1pred/features.py` and `f1pred/predict.py` without corresponding updates in `README.md`, causing documentation to become vague or outdated.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Run the local test suite (requires installing test dependencies first):
 ```bash
 make install
 pip install pytest pytest-cov httpx playwright fastparquet pyarrow colorama
+playwright install --with-deps chromium
 make test
 ```
 


### PR DESCRIPTION
💡 Problem: The "Testing" instructions in `README.md` correctly told developers to pip install `playwright`, but omitted the crucial command to actually install the browser binaries. This leads to immediate test failures when running `make test` on a fresh environment.
🎯 Fix: Added `playwright install --with-deps chromium` to the bash code block under "Testing" in `README.md`.
🧪 Verification: Created a fresh test environment, ran the updated commands, and verified `make test` successfully discovers and passes the Playwright tests (`test_ui_fix.py` and `test_ui_layout.py`).
🔎 Scope: Only `README.md` and `.jules/archivist.md` (to document the learning) were modified. No application code or behavior was altered.

---
*PR created automatically by Jules for task [11763708641242869244](https://jules.google.com/task/11763708641242869244) started by @2fst4u*