### PR TITLE
Fix form index target calculation

### DIFF
--- a/f1pred/calibrate.py
+++ b/f1pred/calibrate.py
@@ -168,6 +168,7 @@ def _calibration_version() -> str:
         + str(PARAM_BOUNDS)
         + str(PARAM_DEFAULTS)
         + str(N_PARAMS)
+        + "v2_form_index"
     )
     return hashlib.sha256(sig.encode()).hexdigest()[:12]
 

--- a/f1pred/features.py
+++ b/f1pred/features.py
@@ -558,12 +558,7 @@ def compute_form_indices(df: pd.DataFrame, ref_date: datetime, half_life_days: i
         is_cur_sprint = (dfg["season"] == current_season) & (dfg["session"] == "sprint")
         w = np.where(is_cur_sprint, w * sprint_boost_factor, w)
     dfg["w"] = w
-    # TODO: Form index conflates position and points (pos_score + pts_score).  The
-    # non-linear points scale (25,18,15,...,1,0,0,...) creates a discontinuity at the
-    # scoring boundary (P10 vs P11) and over-emphasizes podium vs midfield gaps.
-    # Using pos_score alone may be a cleaner target.  Requires further investigation
-    # and confirmation.
-    dfg["weighted_val"] = (dfg["pos_score"] + dfg["pts_score"]) * dfg["w"]
+    dfg["weighted_val"] = dfg["pos_score"] * dfg["w"]
     dfg = dfg.dropna(subset=["driverId"])
 
     driver_codes, uniques = pd.factorize(dfg["driverId"])

--- a/f1pred/models.py
+++ b/f1pred/models.py
@@ -60,12 +60,6 @@ def build_hist_training_X(hist: 'pd.DataFrame', X_current: 'pd.DataFrame',
     if len(races) < 20:
         return None
 
-    # TODO: The form index target is computed as (-position + points), which conflates
-    # finishing position with non-linear championship points (25,18,15,...).  This
-    # disproportionately rewards top-5 finishes and under-differentiates midfield
-    # positions (P11-P20 all receive 0 points).  Using -position alone as the target
-    # may produce a cleaner, more monotonic learning signal.  Requires further
-    # investigation and confirmation.
     races["points"] = races["points"].fillna(0.0)
     races_full["points"] = races_full["points"].fillna(0.0)
 
@@ -109,7 +103,7 @@ def build_hist_training_X(hist: 'pd.DataFrame', X_current: 'pd.DataFrame',
     # Pre-calculate base values (position and points) for races (finishes)
     races_pos = races["position"].values.astype(float)
     races_pts = races["points"].values.astype(float)
-    races_val_base = -races_pos + races_pts
+    races_val_base = -races_pos
 
     # Pre-calculate DNF status from races_full
     if "is_dnf" in races_full.columns:
@@ -389,7 +383,7 @@ def train_pace_model(X: 'pd.DataFrame', session_type: str, cfg: Any = None,
     """
     Train a model producing a "pace index" (lower is better/faster) per driver.
 
-    The form_index is calculated as: -position + points, so HIGHER form_index = BETTER driver.
+    The form_index is calculated as: -position, so HIGHER form_index = BETTER driver.
     For pace (where LOWER = FASTER), we use: y = -form_index as the target.
 
     The model learns to predict pace from features, then we blend with a baseline


### PR DESCRIPTION
Fixes the form index target so that it only relies on the negative finishing position, rather than conflating it with the non-linear points system. This provides a cleaner and more monotonic learning signal for the model. Recalibration is forced via a version bump.

---
*PR created automatically by Jules for task [3933441630611782610](https://jules.google.com/task/3933441630611782610) started by @2fst4u*