### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in webhook test endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The `SECRET_KEY` in `f1pred/auth.py` was hardcoded to a default string `"f1pred-super-secret-key-change-me"`.
 **Learning:** Hardcoded default secrets are a critical vulnerability, as they allow anyone to forge valid JWT tokens and bypass authentication.
 **Prevention:** Always use environment variables for sensitive secrets and provide a cryptographically secure fallback (e.g., `secrets.token_urlsafe(32)`) if the environment variable is not present, to ensure the application fails securely and avoids deterministic, predictable default secrets.
+## 2024-04-19 - Server-Side Request Forgery (SSRF) in Webhook Testing
+**Vulnerability:** The `/api/settings/test-webhook` endpoint blindly accepted a user-provided URL in the `WebhookTestRequest` payload and made an HTTP POST request to it using `httpx.AsyncClient` without validating the host or scheme.
+**Learning:** This is a classic SSRF vulnerability. An attacker could provide internal network addresses (e.g., `http://169.254.169.254` for cloud metadata, `http://localhost:8080`) or local file paths (`file:///etc/passwd`), tricking the application server into scanning internal ports, reading local files, or making unauthorized internal API calls.
+**Prevention:** When an application feature requires sending a webhook to a third-party service based on user input, strictly allowlist the domain or URL prefix (e.g., `https://discord.com/api/webhooks/`). Never allow arbitrary domains, IPs, or non-HTTP(S) schemes.

--- a/f1pred/web.py
+++ b/f1pred/web.py
@@ -545,6 +545,11 @@ async def test_webhook(
     current_user: User = Depends(get_current_user)
 ):
     """Send a test notification to the provided Discord webhook URL."""
+    # 🛡️ Sentinel: Defense in depth - Validate webhook URL to prevent SSRF
+    valid_prefixes = ("https://discord.com/api/webhooks/", "https://discordapp.com/api/webhooks/")
+    if not request.url.startswith(valid_prefixes):
+        raise HTTPException(status_code=400, detail="URL must be a valid Discord webhook URL")
+
     try:
         payload = {
             "embeds": [{

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -29,3 +29,25 @@ def test_get_predict_stream_too_many_sessions(client):
     response = client.get(url)
     assert response.status_code == 400
     assert response.json() == {"detail": "Too many sessions requested"}
+
+@pytest.fixture
+def client_with_auth(client):
+    import f1pred.web as web_module
+
+    # Login to get token
+    response = client.post("/api/auth/token", data={"username": "admin", "password": "admin"})
+    token = response.json()["access_token"]
+
+    client.headers.update({"Authorization": f"Bearer {token}"})
+
+    yield client
+    if web_module._prediction_manager:
+        web_module._prediction_manager.stop()
+
+def test_webhook_ssrf_protection_invalid_scheme(client_with_auth):
+    response = client_with_auth.post("/api/settings/test-webhook", json={"url": "file:///etc/passwd"})
+    assert response.status_code == 400
+
+def test_webhook_ssrf_protection_non_discord(client_with_auth):
+    response = client_with_auth.post("/api/settings/test-webhook", json={"url": "https://example.com"})
+    assert response.status_code == 400


### PR DESCRIPTION
**🚨 Severity:** CRITICAL
**💡 Vulnerability:** The `/api/settings/test-webhook` endpoint blindly accepted a user-provided URL in the `WebhookTestRequest` payload and made an HTTP POST request to it using `httpx.AsyncClient` without validating the host or scheme. This is a Server-Side Request Forgery (SSRF) vulnerability.
**🎯 Impact:** An attacker could exploit this to make the application server scan internal ports, retrieve cloud provider metadata (e.g. AWS `169.254.169.254`), read local files (e.g. via `file://`), or make unauthorized requests to internal API services behind the firewall.
**🔧 Fix:** Added defense-in-depth validation to strictly ensure `request.url` begins with `https://discord.com/api/webhooks/` or `https://discordapp.com/api/webhooks/`. If it doesn't, the endpoint immediately returns a 400 Bad Request error. Also added tests to verify this protection.
**✅ Verification:** Run `make test` or `python -m pytest tests/test_web_security.py` to confirm that SSRF attempts (e.g. `file://`, `http://localhost`, `https://example.com`) are properly blocked.

---
*PR created automatically by Jules for task [4253704301345617221](https://jules.google.com/task/4253704301345617221) started by @2fst4u*