### PR TITLE
Fix OpenCode Git Identity Configuration

### DIFF
--- a/.github/workflows/opencode-easy.yml
+++ b/.github/workflows/opencode-easy.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 1
-          persist-credentials: false
 
       - name: Run OpenCode
         uses: anomalyco/opencode/github@latest

--- a/.github/workflows/opencode-hard.yml
+++ b/.github/workflows/opencode-hard.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 1
-          persist-credentials: false
 
       - name: Run OpenCode
         uses: anomalyco/opencode/github@latest

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -14,8 +14,6 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@v4.2.2
-        with:
-          persist-credentials: false
 
       - uses: anomalyco/opencode/github@latest
         env:


### PR DESCRIPTION
Fixes an issue where OpenCode integration actions fail to push new branches because Git is lacking a configured user identity. Removign `persist-credentials: false` from `actions/checkout` allows the GitHub Actions bot token and user configuration to be safely persisted in `.git/config` for OpenCode's subsequent steps to use.

---
*PR created automatically by Jules for task [6227033815482303819](https://jules.google.com/task/6227033815482303819) started by @2fst4u*