### PR TITLE
fix: Trigger opencode review bot only on PR comments with /oc-review

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,11 +1,15 @@
 name: opencode-review
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
 
 jobs:
   review:
+    if: |
+      (github.event.issue.pull_request != null || github.event.pull_request != null) && contains(github.event.comment.body, '/oc-review')
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
- Modified `.github/workflows/opencode-review.yml` to trigger on `issue_comment` and `pull_request_review_comment` events instead of automatically on `pull_request` pushes/creation.
- Added an `if` condition to only execute the bot when the comment body contains `/oc-review`.
- Ensured the bot only triggers for pull requests, rejecting regular issues.

---
*PR created automatically by Jules for task [5449228640218641765](https://jules.google.com/task/5449228640218641765) started by @2fst4u*