### PR TITLE
🧹 Sweep: Remove unused `wb_dt` variable assignment

### DIFF
--- a/f1pred/calibrate.py
+++ b/f1pred/calibrate.py
@@ -783,7 +783,6 @@ class CalibrationManager:
                 wb_gbm = max(0, weights[0])
                 wb_form = max(0, weights[1])
                 wb_tm = max(0, weights[2])
-                wb_dt = max(0, weights[3])
                 wb_grid = np.clip(weights[4], 0.0, 1.0)
 
                 we_pace = max(0, weights[5])


### PR DESCRIPTION
💡 **What**: Removed the unread variable assignment `wb_dt` in `f1pred/calibrate.py`.

🎯 **Why**: The variable `wb_dt` was assigned a value from `weights[3]` but was never subsequently used in the calibration logic. Removing this dead code prevents allocating an unread variable, satisfies `flake8`/`ruff` linting requirements, and keeps the mathematical assignment block clean and accurate. 

🔬 **Verification**: 
1. Ran `grep -rnH "wb_dt" f1pred/calibrate.py` and confirmed no remaining references.
2. Ran `ruff check .` which showed the unused assignment warning was resolved.
3. Ran the full test suite via `python3 -m pytest tests` to verify the removal had no unintended side effects.

---
*PR created automatically by Jules for task [14078975925581682229](https://jules.google.com/task/14078975925581682229) started by @2fst4u*