### PR TITLE
Fix opencode bots replying to unmentioned discussion comments

### DIFF
--- a/.github/workflows/opencode-easy.yml
+++ b/.github/workflows/opencode-easy.yml
@@ -43,3 +43,4 @@ jobs:
         with:
           agent: worker-easy
           use_github_token: true
+          mentions: '/oc-easy'

--- a/.github/workflows/opencode-hard.yml
+++ b/.github/workflows/opencode-hard.yml
@@ -43,3 +43,4 @@ jobs:
         with:
           agent: worker-hard
           use_github_token: true
+          mentions: '/oc-hard'

--- a/.github/workflows/opencode-plan.yml
+++ b/.github/workflows/opencode-plan.yml
@@ -35,3 +35,4 @@ jobs:
         with:
           agent: plan
           use_github_token: true
+          mentions: '/oc-plan'

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           model: openrouter/anthropic/claude-3.7-sonnet
           use_github_token: true
+          mentions: '/oc-review'
           prompt: |
             Review this pull request as an expert software engineer:
             - Identify critical security vulnerabilities or bugs.


### PR DESCRIPTION
This PR restricts the OpenCode GitHub Action bots to strictly respond only to comments that contain their specific slash command trigger (e.g., `/oc-review`), rather than replying to generic subsequent discussion comments in the thread.

**Why?**
The underlying GitHub Action `anomalyco/opencode/github@latest` scans the entire issue/PR thread. Without an explicit `mentions` parameter, it defaults to answering generic `/oc` or `/opencode` invocations or tries to process the last comment, leading to noise and auto-replies on discussions between engineers following an initial bot call. 

**What Changed:**
Added the `mentions` argument directly to the action parameters for:
* `opencode-review.yml` -> `mentions: '/oc-review'`
* `opencode-easy.yml` -> `mentions: '/oc-easy'`
* `opencode-hard.yml` -> `mentions: '/oc-hard'`
* `opencode-plan.yml` -> `mentions: '/oc-plan'`

---
*PR created automatically by Jules for task [1754351032790398685](https://jules.google.com/task/1754351032790398685) started by @2fst4u*