### PR TITLE
Fix missing MODEL environment variable in OpenCode workflows

### DIFF
--- a/.github/workflows/opencode-easy.yml
+++ b/.github/workflows/opencode-easy.yml
@@ -40,6 +40,7 @@ jobs:
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT || secrets.GITHUB_TOKEN }}
+          MODEL: openrouter/moonshotai/kimi-k2.6
         with:
           agent: worker-easy
           use_github_token: true

--- a/.github/workflows/opencode-hard.yml
+++ b/.github/workflows/opencode-hard.yml
@@ -40,6 +40,7 @@ jobs:
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT || secrets.GITHUB_TOKEN }}
+          MODEL: openrouter/anthropic/claude-opus-4.7
         with:
           agent: worker-hard
           use_github_token: true

--- a/.github/workflows/opencode-plan.yml
+++ b/.github/workflows/opencode-plan.yml
@@ -32,6 +32,7 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT || secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.OPENCODE_PAT || secrets.GITHUB_TOKEN }}
+          MODEL: openrouter/google/gemini-2.5-pro
         with:
           agent: plan
           use_github_token: true


### PR DESCRIPTION
Fix missing MODEL environment variable in OpenCode workflows

Reverts previous changes that erroneously added the unsupported `env:` block directly to the `.md` files since agent configuration cannot export variables to the runner shell environment. 

Instead, updates the `.github/workflows/opencode-plan.yml`, `.github/workflows/opencode-easy.yml`, and `.github/workflows/opencode-hard.yml` files to explicitly set the `MODEL` environment variable. This ensures the `opencode` execution context correctly resolves the missing configuration error, while allowing the workflows to continue to utilize the prompts stored cleanly within their respective `.md` configuration files.

---
*PR created automatically by Jules for task [10679980737030303650](https://jules.google.com/task/10679980737030303650) started by @2fst4u*