### PR TITLE
Improved UI spacing and readability.

### DIFF
--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -135,7 +135,7 @@
             <div class="max-w-[1400px] w-full mx-auto flex justify-between items-center flex-wrap gap-2 border-b border-red-700 pb-3">
                 <h1 class="text-xl md:text-2xl font-black tracking-tighter italic whitespace-nowrap">F1 OUTCOME
                     PREDICTOR</h1>
-                <div class="flex items-center space-x-2 min-w-0">
+                <div class="flex items-center space-x-3 min-w-0">
                     <!-- Live indicator -->
                     <template x-if="liveConnected">
                         <span class="flex items-center space-x-1 bg-black bg-opacity-20 px-2 py-1 rounded"
@@ -172,24 +172,24 @@
         </header>
 
         <!-- Navigation Tabs -->
-        <div class="max-w-[1400px] mx-auto px-2 sm:px-4 mb-4 mt-4">
-            <div class="flex space-x-4 border-b border-gray-700">
+        <div class="max-w-[1400px] mx-auto px-4 sm:px-6 mb-6 mt-6">
+            <div class="flex space-x-6 border-b border-gray-700">
                 <button @click="activeTab = 'predictions'"
                     :class="activeTab === 'predictions' ? 'border-red-500 text-white' : 'border-transparent text-gray-400 hover:text-gray-300'"
-                    class="py-2 px-1 border-b-2 font-medium text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded">
+                    class="py-3 px-4 border-b-2 font-medium text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded">
                     Predictions
                 </button>
                     <button @click="activeTab = 'settings'"
                     :class="activeTab === 'settings' ? 'border-red-500 text-white' : 'border-transparent text-gray-400 hover:text-gray-300'"
-                    class="py-2 px-3 border-b-2 font-medium text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded-t-md transition-colors duration-200">
+                    class="py-3 px-4 border-b-2 font-medium text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded-t-md transition-colors duration-200">
                     Settings
                 </button>
             </div>
         </div>
 
-        <main class="max-w-[1400px] w-full mx-auto px-2 py-4 md:p-8" x-show="activeTab === 'predictions'">
+        <main class="max-w-[1400px] w-full mx-auto px-4 py-6 md:p-10" x-show="activeTab === 'predictions'">
             <!-- Controls -->
-            <div class="card p-4 md:p-6 mb-4 md:mb-8 shadow-xl">
+            <div class="card p-5 md:p-8 mb-6 md:mb-10 shadow-xl">
                 <div class="flex flex-col gap-4">
                     <div class="flex justify-between items-end gap-4">
                         <div class="flex items-center gap-2">
@@ -200,8 +200,8 @@
                     </div>
 
                     <div>
-                        <div id="round-label" class="block text-xs font-bold text-gray-400 mb-2 uppercase tracking-wider">Round (Auto-Predicted)</div>
-                        <div role="group" aria-labelledby="round-label" tabindex="0" class="flex space-x-2 overflow-x-auto no-scrollbar pb-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded" :class="{'opacity-50 pointer-events-none': scheduleLoading}">
+                        <div id="round-label" class="block text-xs font-bold text-gray-400 mb-3 uppercase tracking-wider">Round (Auto-Predicted)</div>
+                        <div role="group" aria-labelledby="round-label" tabindex="0" class="flex space-x-3 overflow-x-auto no-scrollbar pb-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded" :class="{'opacity-50 pointer-events-none': scheduleLoading}">
                             <template x-if="scheduleLoading">
                                 <span class="flex items-center text-xs text-gray-500 italic mt-1.5 pt-1">
                                     <i class="fas fa-circle-notch fa-spin mr-1.5" aria-hidden="true"></i>Loading schedule...
@@ -384,21 +384,21 @@
                                     <thead>
                                         <tr
                                             class="bg-gray-800 text-xs font-bold text-gray-400 uppercase tracking-wider">
-                                            <th scope="col" class="py-2 sm:p-4 w-7 sm:w-12 text-center"><abbr
+                                            <th scope="col" class="py-3 sm:p-5 w-7 sm:w-12 text-center"><abbr
                                                     title="Predicted Position"
                                                     class="cursor-help underline decoration-dotted decoration-gray-500 underline-offset-4 hover:text-white transition-colors">Pos</abbr>
                                             </th>
-                                            <th scope="col" class="py-2 sm:p-4">Driver</th>
-                                            <th scope="col" class="py-2 sm:p-4 hidden md:table-cell">Team</th>
-                                            <th scope="col" class="py-2 sm:p-4 text-center"
+                                            <th scope="col" class="py-3 sm:p-5">Driver</th>
+                                            <th scope="col" class="py-3 sm:p-5 hidden md:table-cell">Team</th>
+                                            <th scope="col" class="py-3 sm:p-5 text-center"
                                                 x-show="hasGrid(sess) && !data.frozen"><abbr title="Predicted finish compared to starting grid"
                                                     class="cursor-help underline decoration-dotted decoration-gray-500 underline-offset-4 hover:text-white transition-colors">Grid & Exp Delta</abbr>
                                             </th>
-                                            <th scope="col" class="py-2 sm:p-4 text-center text-blue-300"
+                                            <th scope="col" class="py-3 sm:p-5 text-center text-blue-300"
                                                 x-show="data.frozen"><abbr title="Actual finish compared to predicted finish"
                                                     class="cursor-help underline decoration-dotted decoration-blue-500 underline-offset-4 hover:text-blue-200 transition-colors">Real Pos & Acc.</abbr>
                                             </th>
-                                            <th scope="col" class="py-2 sm:p-4">
+                                            <th scope="col" class="py-3 sm:p-5">
                                                 <span class="hidden sm:inline"
                                                     x-text="['qualifying', 'sprint_qualifying'].includes(sess) ? 'Pole Prob' : 'Win Prob'">Win
                                                     Prob</span>
@@ -406,11 +406,11 @@
                                                     x-text="['qualifying', 'sprint_qualifying'].includes(sess) ? 'Pole %' : 'Win %'">Win
                                                     %</span>
                                             </th>
-                                            <th scope="col" class="py-2 sm:p-4">
+                                            <th scope="col" class="py-3 sm:p-5">
                                                 <span class="hidden sm:inline">Podium</span>
                                                 <span class="sm:hidden">Top 3</span>
                                             </th>
-                                            <th scope="col" class="py-2 sm:p-4 text-right"
+                                            <th scope="col" class="py-3 sm:p-5 text-right"
                                                 x-show="['race', 'sprint'].includes(sess)"><abbr
                                                     title="Did Not Finish Probability"
                                                     class="cursor-help underline decoration-dotted decoration-gray-500 underline-offset-4 hover:text-white transition-colors">DNF</abbr>
@@ -422,11 +422,11 @@
                                             <tr :class="[getTeamClass(p.constructorName), getMovementClass(p.driverId, sess)]"
                                                 class="text-sm sm:text-base transition-colors">
                                                 <!-- Position -->
-                                                <td class="pt-2 sm:p-4 text-center font-black italic text-base sm:text-lg align-top"
+                                                <td class="pt-3 sm:p-5 text-center font-black italic text-base sm:text-lg align-top"
                                                     :class="index === 0 ? 'text-yellow-400' : index === 1 ? 'text-gray-300' : index === 2 ? 'text-amber-600' : 'text-gray-500'"
                                                     x-text="p.predicted_position"></td>
                                                 <!-- Driver -->
-                                                <td class="pt-2 sm:p-4 align-top">
+                                                <td class="pt-3 sm:p-5 align-top">
                                                     <div class="flex items-center space-x-1 sm:space-x-3 mb-0.5">
                                                         <!-- Movement arrow -->
                                                         <template x-if="getDriverMovement(p.driverId, sess)">
@@ -449,12 +449,12 @@
                                                 </td>
                                                 <!-- Team -->
                                                 <td
-                                                    class="pt-2 sm:p-4 hidden md:table-cell align-top">
+                                                    class="pt-3 sm:p-5 hidden md:table-cell align-top">
                                                     <span class="text-sm text-gray-400"
                                                         x-text="p.constructorName">Team</span>
                                                 </td>
                                                 <!-- Grid & Pred Delta (Unfrozen) -->
-                                                <td class="pt-2 sm:p-4 text-center align-top"
+                                                <td class="pt-3 sm:p-5 text-center align-top"
                                                     x-show="hasGrid(sess) && !data.frozen">
                                                     <div class="flex flex-col items-center mt-1">
                                                         <span class="text-[10px] text-gray-500 mb-0.5">Start P<span x-text="p.grid || '--'"></span></span>
@@ -471,7 +471,7 @@
                                                 </td>
 
                                                 <!-- Actual & Accuracy (Frozen) -->
-                                                <td class="pt-2 sm:p-4 text-center align-top"
+                                                <td class="pt-3 sm:p-5 text-center align-top"
                                                     x-show="data.frozen">
                                                     <div class="flex flex-col items-center">
                                                         <span class="font-black text-xl text-blue-400">P<span x-text="p.actual_position || '?'"></span></span>
@@ -486,7 +486,7 @@
                                                     </div>
                                                 </td>
                                                 <!-- Win % -->
-                                                <td class="pt-2 sm:p-4 align-top">
+                                                <td class="pt-3 sm:p-5 align-top">
                                                     <div class="w-10 sm:w-24">
                                                         <div class="text-xs mb-0.5 sm:mb-1"
                                                             x-text="(p.p_win * 100).toFixed(1) + '%'"></div>
@@ -498,7 +498,7 @@
                                                     </div>
                                                 </td>
                                                 <!-- Top 3 % -->
-                                                <td class="pt-2 sm:p-4 align-top">
+                                                <td class="pt-3 sm:p-5 align-top">
                                                     <div class="w-10 sm:w-24">
                                                         <div class="text-xs mb-0.5 sm:mb-1"
                                                             x-text="(p.p_top3 * 100).toFixed(1) + '%'"></div>
@@ -510,7 +510,7 @@
                                                     </div>
                                                 </td>
                                                 <!-- DNF % -->
-                                                <td class="pt-2 sm:p-4 text-right align-top"
+                                                <td class="pt-3 sm:p-5 text-right align-top"
                                                     x-show="['race', 'sprint'].includes(sess)">
                                                     <div class="w-10 sm:w-24 ml-auto">
                                                         <div class="text-xs mb-0.5 sm:mb-1"
@@ -527,7 +527,7 @@
                                             <tr :class="getTeamClass(p.constructorName)"
                                                 x-show="p.ensemble_components || hasShapFactors(p.shap_values)">
                                                 <td :colspan="getColspan(sess)"
-                                                    class="px-1.5 md:px-8 lg:px-12 pb-3 border-t border-gray-800/50">
+                                                    class="px-3 md:px-10 lg:px-14 pb-5 border-t border-gray-800/50">
                                                     <div
                                                         class="flex flex-wrap md:flex-nowrap gap-x-4 gap-y-4 items-start md:justify-start w-full">
                                                         <!-- Model Mix bar removed per user request -->
@@ -535,18 +535,18 @@
                                                         <template x-if="hasShapFactors(p.shap_values)">
                                                             <div class="min-w-0 w-full flex-1">
                                                                 <div
-                                                                    class="text-xs font-bold text-gray-500 uppercase tracking-widest mb-0.5 text-center md:text-left w-full">
+                                                                    class="text-xs font-bold text-gray-500 uppercase tracking-widest mb-2 text-center md:text-left w-full">
                                                                     Factors <span
                                                                         class="normal-case font-normal text-gray-600">(green
                                                                         = helps, red = hurts)</span>
                                                                 </div>
                                                                 <div
-                                                                    class="flex flex-nowrap md:gap-x-4 gap-y-0.5 overflow-hidden no-scrollbar justify-around md:justify-start w-full">
+                                                                    class="flex flex-nowrap md:gap-x-6 gap-y-2 overflow-hidden no-scrollbar justify-around md:justify-start w-full">
                                                                     <template
                                                                         x-for="feat in getSortedShap(p.shap_values, windowWidth)"
                                                                         :key="feat.key + '_' + windowWidth">
                                                                         <div
-                                                                            class="flex flex-col flex-shrink-0 gap-0.5 text-xs w-[80px] md:w-[110px]">
+                                                                            class="flex flex-col flex-shrink-0 gap-1 text-xs w-[80px] md:w-[110px]">
                                                                             <div class="flex items-center gap-1 h-3 mt-0.5 mb-0.5">
                                                                                 <span class="sr-only"
                                                                                     x-text="feat.val < 0 ? 'Improves position:' : 'Worsens position:'"></span>
@@ -580,7 +580,7 @@
                                     </template>
                                 </table>
 
-                                <div class="mt-3 rounded border border-gray-700 bg-gray-900/40 p-3">
+                                <div class="mt-4 rounded border border-gray-700 bg-gray-900/40 p-5">
                                     <div class="text-xs font-bold uppercase tracking-widest text-gray-400 mb-2">
                                         Influence Legend</div>
                                     <div class="grid grid-cols-1 gap-3 text-xs text-gray-300">
@@ -602,10 +602,10 @@
                                             class="cursor-pointer text-xs font-bold uppercase tracking-widest text-gray-400 hover:text-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 rounded transition">
                                             Input Variable Glossary</summary>
                                         <div
-                                            class="mt-2 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-4 gap-y-1 text-xs">
+                                            class="mt-2 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-2 text-xs">
                                             <template x-for="entry in getFeatureLegendEntries()" :key="entry.key">
                                                 <div
-                                                    class="flex justify-between gap-2 text-gray-300 border-b border-gray-800/60 pb-0.5">
+                                                    class="flex justify-between gap-2 text-gray-300 border-b border-gray-800/60 pb-1">
                                                     <span class="truncate" x-text="entry.label"></span>
                                                     <span class="text-gray-500 font-mono" x-text="entry.key"></span>
                                                 </div>
@@ -628,8 +628,8 @@
         </main>
 
         <!-- Settings View -->
-        <main class="max-w-[1400px] w-full mx-auto px-2 py-4 md:p-8" x-show="activeTab === 'settings'" style="display: none;">
-            <div class="bg-gray-800 rounded-lg p-6 border border-gray-700 max-w-2xl">
+        <main class="max-w-[1400px] w-full mx-auto px-4 py-6 md:p-10" x-show="activeTab === 'settings'" style="display: none;">
+            <div class="bg-gray-800 rounded-lg p-8 border border-gray-700 max-w-2xl">
                 <h2 class="text-xl font-bold mb-6 text-white border-b border-gray-700 pb-2">Application Settings</h2>
 
                 <template x-if="!isLoggedIn">
@@ -638,7 +638,7 @@
 
                         <div x-show="authError" class="mb-4 bg-red-900/50 border-l-4 border-red-500 p-4 text-red-200" x-text="authError"></div>
 
-                        <form @submit.prevent="login" class="space-y-4">
+                        <form @submit.prevent="login" class="space-y-5">
                             <div>
                                 <label for="login-username" class="block text-sm font-medium text-gray-300">Username</label>
                                 <input id="login-username" type="text" x-model="authUsername" required
@@ -666,8 +666,8 @@
 
                         <div class="mb-8 border-b border-gray-700 pb-8">
                             <h3 class="text-sm font-medium text-gray-200 mb-3">Account Security</h3>
-                            <div class="bg-gray-900/50 p-4 rounded border border-gray-700">
-                                <form @submit.prevent="changePassword" class="space-y-4">
+                            <div class="bg-gray-900/50 p-5 rounded border border-gray-700">
+                                <form @submit.prevent="changePassword" class="space-y-5">
                                     <div x-show="passwordChangeError" class="text-xs text-red-400" x-text="passwordChangeError"></div>
                                     <div x-show="passwordChangeSuccess" class="text-xs text-green-400">Password changed successfully!</div>
 
@@ -691,10 +691,10 @@
                             </div>
                         </div>
 
-                        <form @submit.prevent="saveSettings" class="space-y-6">
+                        <form @submit.prevent="saveSettings" class="space-y-8">
                             <div>
                                 <h3 class="text-sm font-medium text-gray-200 mb-3">Notifications</h3>
-                                <div class="bg-gray-900/50 p-4 rounded border border-gray-700">
+                                <div class="bg-gray-900/50 p-5 rounded border border-gray-700">
                                     <label for="discord-webhook-url" class="block text-sm font-medium text-gray-400 mb-1">Discord Webhook URL</label>
                                     <div class="flex gap-2">
                                         <input id="discord-webhook-url" type="text" x-model="settings.discord_webhook_url" placeholder="https://discord.com/api/webhooks/..."
@@ -713,7 +713,7 @@
 
                             <div>
                                 <h3 class="text-sm font-medium text-gray-200 mb-3">Integrations (Coming Soon)</h3>
-                                <div class="bg-gray-900/50 p-4 rounded border border-gray-700 space-y-4 opacity-50 pointer-events-none">
+                                <div class="bg-gray-900/50 p-5 rounded border border-gray-700 space-y-4 opacity-50 pointer-events-none">
                                     <div>
                                         <label class="block text-sm font-medium text-gray-400 mb-1">LLM Server URL</label>
                                         <input type="text" x-model="settings.llm_server_url" disabled


### PR DESCRIPTION
Done. I've improved the spacing and readability across `f1pred/templates/index.html` with the following cohesive adjustments:

- **Main content & header:** Increased horizontal padding on both prediction and settings views; increased spacing between header version badges and the refresh button.
- **Navigation tabs:** Increased outer container padding/margins, widened tab spacing (`space-x-6`), and bumped tab padding to `py-3 px-4` for consistent, taller tabs.
- **Prediction controls:** Enlarged the card padding (`p-5 md:p-8`), increased bottom margin, and added more space between the round label and round selection buttons (`space-x-3`).
- **Results table:** Increased header and data cell padding from `py-2 / pt-2` to `py-3 / pt-3`, and `sm:p-4` to `sm:p-5` for less cramped cells.
- **SHAP factors & glossary:** Increased padding and gaps inside the influence panel, factors heading margin, and glossary item spacing for clearer visual grouping.
- **Settings page:** Enlarged the settings card padding, increased vertical spacing in the login, password change, and save-settings forms, and padded the inner settings containers more generously.

Closes #389

<a href="https://opencode.ai/s/PF9cfEAV"><img width="200" alt="New%20session%20-%202026-04-23T05%3A27%3A19.651Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA0LTIzVDA1OjI3OjE5LjY1MVo=.png?model=openrouter/moonshotai/kimi-k2.6&version=1.14.20&id=PF9cfEAV" /></a>
[opencode session](https://opencode.ai/s/PF9cfEAV)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/2fst4u/f1predictor/actions/runs/24818498142)