### PR TITLE
feat: Add standalone OpenCode auto workflow with pareto-code

### DIFF
--- a/.github/workflows/opencode-auto.yml
+++ b/.github/workflows/opencode-auto.yml
@@ -1,0 +1,47 @@
+name: opencode-auto
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, '/oc-auto')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
+      pull-requests: write
+      issues: write
+    # OPENCODE_PAT requires the following repository permissions:
+    # - Contents: Read & Write
+    # - Issues: Read & Write
+    # - Pull Requests: Read & Write
+    # - Workflows: Read & Write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 1
+          persist-credentials: true
+          token: ${{ secrets.OPENCODE_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Run OpenCode
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.OPENCODE_PAT || secrets.GITHUB_TOKEN }}
+        with:
+          model: openrouter/pareto-code
+          use_github_token: true
+          mentions: '/oc-auto'

--- a/opencode.json
+++ b/opencode.json
@@ -11,7 +11,8 @@
         "openai/gpt-4o-mini": {},
         "anthropic/claude-sonnet-4.6": {},
         "anthropic/claude-3.7-sonnet": {},
-        "moonshotai/kimi-k2.6": {}
+        "moonshotai/kimi-k2.6": {},
+        "pareto-code": {}
       }
     }
   }


### PR DESCRIPTION
This PR introduces a standalone OpenCode bot workflow (`opencode-auto.yml`) that can be invoked on-demand by commenting `/oc-auto` on issues or pull requests. 

**Changes:**
- Added `.github/workflows/opencode-auto.yml` configured to run `anomalyco/opencode/github@latest` triggered by `/oc-auto`.
- Uses `openrouter/pareto-code` directly as the target model.
- Operates entirely independently of existing agents (`worker-easy`, `worker-hard`, `plan`, `review`).
- Added the `pareto-code` key to `opencode.json` under `provider.openrouter.models` to ensure the OpenCode action recognizes the model and prevents execution hangs.

**Verification:**
- Verified the workflow structure matches existing conventions but limits scope appropriately.
- Verified test suite passes locally.

---
*PR created automatically by Jules for task [3285898337341030350](https://jules.google.com/task/3285898337341030350) started by @2fst4u*