### PR TITLE
Added meta_override; fixed weather DNF bug

### DIFF
--- a/f1pred/predict.py
+++ b/f1pred/predict.py
@@ -430,10 +430,13 @@ def _run_single_prediction(
     ref_date: datetime,
     cfg,
     X_override: Optional['pd.DataFrame'] = None,
+    meta_override: Optional[Dict[str, Any]] = None,
 ) -> Optional['pd.DataFrame']:
     """Run prediction for a single session and return ranked DataFrame.
     
     If X_override is provided, use it instead of building features.
+    meta_override may be supplied alongside X_override to pass session
+    metadata (e.g. weather) used by downstream estimation stages.
     Returns None if prediction cannot be completed.
     """
     from .features import build_session_features, collect_historical_results
@@ -445,7 +448,7 @@ def _run_single_prediction(
     if X_override is not None:
         X = X_override.copy()
         roster = X_override.copy()
-        meta = {}
+        meta = meta_override if meta_override is not None else {}
     else:
         X, meta, roster = build_session_features(jc, om, season_i, round_i, sess, ref_date, cfg)
     
@@ -525,9 +528,6 @@ def _run_single_prediction(
         combined_pace = pace_hat
     
     # DNF probabilities (only for race/sprint)
-    # TODO: When X_override is provided, meta is an empty dict so event_weather is
-    # always None here, causing weather-aware DNF rates to fall back to overall rates.
-    # Requires further investigation and confirmation.
     dnf_prob = np.zeros(X.shape[0], dtype=float)
     if sess in ("race", "sprint"):
         try:


### PR DESCRIPTION
All tests pass. Here's a summary of the fix:

**Changed:** `f1pred/predict.py` — `_run_single_prediction`

1. **Added `meta_override` parameter** (`Optional[Dict[str, Any]] = None`) as a companion to the existing `X_override`.
2. **Updated feature-override path** so that when `X_override` is provided, `meta` is taken from `meta_override` instead of hardcoded `{}`. If `meta_override` is not supplied, it still falls back to `{}` (preserving existing behavior).
3. **Updated docstring** to document the new parameter.
4. **Removed the TODO comment** at lines 528–530, since the latent bug is now closed.

This ensures that callers using `X_override` can also pass matching session metadata (e.g. weather) so `estimate_dnf_probabilities` receives `event_weather` correctly instead of silently falling back to overall DNF rates. No current callers pass `X_override`, so observed behavior is unchanged.

Closes #419

<a href="https://opencode.ai/s/3nkZteFr"><img width="200" alt="New%20session%20-%202026-04-23T19%3A15%3A52.951Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA0LTIzVDE5OjE1OjUyLjk1MVo=.png?model=openrouter/moonshotai/kimi-k2.6&version=1.14.22&id=3nkZteFr" /></a>
[opencode session](https://opencode.ai/s/3nkZteFr)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/2fst4u/f1predictor/actions/runs/24854059031)