### PR TITLE
🧪 Spec: Add get_by_key/set_by_key tests to PredictionCache

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -4,3 +4,5 @@ When attempting to mock functions that are locally imported within a method's bo
 
 ### Avoiding application logic changes for tests
 When an application's data transformations (e.g., rounding) crash on `None` values (like `math.isnan`), do not alter the application code to handle the `None` just so a test can assert how it behaves. Instead, write tests that pass valid types or verify the exception is handled upstream if that is the intended behavior.
+## 2024-05-18 - PredictionCache Mocking and Coverage
+When adding tests to `PredictionCache` (in `f1pred/util.py`) for the explicit `get_by_key` and `set_by_key` methods, you must mock `hashlib.sha256` to force a write error for testing error handling since standard OS/file permissions can be tricky to guarantee a write failure across all environments safely.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,6 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 66.10
+fail_under = 68.05
 show_missing = true
 precision = 2

--- a/tests/test_util_cache.py
+++ b/tests/test_util_cache.py
@@ -121,3 +121,63 @@ def test_cache_rolling_deletion_unlink_fails(tmp_path):
 
     # Assert that exception was caught and ignored (files won't actually be deleted)
     assert len(list(cache.cache_dir.glob("*.json"))) == 3
+
+def test_cache_get_by_key_set_by_key_success(tmp_path):
+    cache = PredictionCache(cache_dir=str(tmp_path), max_entries=2)
+    key = "explicit_key_123"
+    df = pd.DataFrame({"a": [1, 2]})
+    results = {
+        "ranked": df,
+        "prob_matrix": np.array([[0.5, 0.5]]),
+        "pairwise": np.array([[1.0, 0.0], [0.0, 1.0]]),
+        "extra": "value"
+    }
+
+    cache.set_by_key(key, results)
+
+    data = cache.get_by_key(key)
+    assert data is not None
+    assert isinstance(data["ranked"], pd.DataFrame)
+    assert data["ranked"].equals(df)
+    assert np.array_equal(data["prob_matrix"], results["prob_matrix"])
+    assert np.array_equal(data["pairwise"], results["pairwise"])
+    assert data["extra"] == "value"
+
+def test_cache_get_by_key_miss(tmp_path):
+    cache = PredictionCache(cache_dir=str(tmp_path), max_entries=2)
+    data = cache.get_by_key("nonexistent_key")
+    assert data is None
+
+def test_cache_get_by_key_error_handling(tmp_path, caplog):
+    cache = PredictionCache(cache_dir=str(tmp_path), max_entries=2)
+    key = "error_key"
+    results = {"val": 42}
+    cache.set_by_key(key, results)
+
+    import hashlib
+    safe_key = hashlib.sha256(key.encode("utf-8")).hexdigest()
+    cache_file = cache.cache_dir / f"{safe_key}.json"
+
+    # Corrupt the JSON file to trigger Exception during load
+    with open(cache_file, "w") as f:
+        f.write("{invalid_json:")
+
+    with caplog.at_level(logging.WARNING):
+        data = cache.get_by_key(key)
+
+    assert data is None
+    assert "Failed to load prediction cache" in caplog.text
+
+def test_cache_set_by_key_error_handling(tmp_path, caplog):
+    cache = PredictionCache(cache_dir=str(tmp_path), max_entries=2)
+    key = "error_key"
+    results = {"val": 42}
+
+    with patch("hashlib.sha256") as mock_sha256:
+        # Create a mock object that returns a problematic string
+        mock_hexdigest = mock_sha256.return_value
+        mock_hexdigest.hexdigest.return_value = "nonexistent_dir/file"
+
+        with caplog.at_level(logging.WARNING):
+            cache.set_by_key(key, results)
+        assert "Failed to save prediction cache" in caplog.text


### PR DESCRIPTION
💡 **What:** 
Added dedicated unit tests (`test_cache_get_by_key_set_by_key_success`, `test_cache_get_by_key_miss`, `test_cache_get_by_key_error_handling`, `test_cache_set_by_key_error_handling`) in `tests/test_util_cache.py` to cover the previously uncovered `get_by_key` and `set_by_key` methods of the `PredictionCache` class in `f1pred/util.py`.

🎯 **Why:** 
The explicit key-based caching methods were uncovered in the test suite, representing a potential vulnerability in the core infrastructure since they are heavily relied upon by the prediction pipeline (`predict.py`) to store and retrieve historical, probabilistic prediction data. Adding tests ensures these critical pathways behave robustly under normal conditions and fail gracefully when encountering corrupt data or write errors.

📈 **Maturity Impact:** 
Bumped coverage threshold from 66.10% to 68.05% to lock in progress toward business standards.

---
*PR created automatically by Jules for task [2213730115141095232](https://jules.google.com/task/2213730115141095232) started by @2fst4u*