### PR TITLE
Fix TODO #3: Add sprint weight param

### DIFF
--- a/f1pred/calibrate.py
+++ b/f1pred/calibrate.py
@@ -79,6 +79,7 @@ PARAM_NAMES = [
     "ens_elo_quali",            # 22
     "ens_bt_quali",             # 23
     "ens_mixed_quali",          # 24
+    "current_season_sprint_weight", # 25
 ]
 
 N_PARAMS = len(PARAM_NAMES)
@@ -115,6 +116,7 @@ PARAM_BOUNDS = [
     (0.0, 0.5),     # 22 ens_elo_quali   (capped lower — race-only model)
     (0.0, 0.5),     # 23 ens_bt_quali    (capped lower — race-only model)
     (0.0, 0.5),     # 24 ens_mixed_quali (capped lower — race-only model)
+    (3.0, 50.0),    # 25 current_season_sprint_weight
 ]
 
 # Default / initial guess (matches config.yaml defaults)
@@ -144,6 +146,7 @@ PARAM_DEFAULTS = [
     0.1,    # 22 ens_elo_quali
     0.1,    # 23 ens_bt_quali
     0.1,    # 24 ens_mixed_quali
+    8.0,    # 25 current_season_sprint_weight
 ]
 
 
@@ -221,6 +224,7 @@ def _unpack_weights(w) -> Dict[str, Any]:
             "current_season_qualifying_weight": float(w[9]),
             "current_quali_factor": float(np.clip(w[10], 0.0, 1.0)),
             "analytical_win_weight": float(np.clip(w[11], 0.0, 1.0)),
+            "current_season_sprint_weight": float(w[25]) if len(w) > 25 else 8.0,
         },
         "dnf": {
             "alpha": float(max(0.1, w[12])),
@@ -277,6 +281,7 @@ def _pack_weights(d: Dict[str, Any]) -> list:
         e.get("w_elo_quali", PARAM_DEFAULTS[22]),
         e.get("w_bt_quali", PARAM_DEFAULTS[23]),
         e.get("w_mixed_quali", PARAM_DEFAULTS[24]),
+        b.get("current_season_sprint_weight", PARAM_DEFAULTS[25]),
     ]
 
 

--- a/f1pred/config.py
+++ b/f1pred/config.py
@@ -126,6 +126,7 @@ class BlendingCfg:
     baseline_team_factor: float = 0.3
     grid_factor: float = 0.8
     current_season_weight: float = 8.0
+    current_season_sprint_weight: float = 8.0
     current_season_qualifying_weight: float = 8.0
     current_quali_factor: float = 0.5
     analytical_win_weight: float = 0.5

--- a/f1pred/features.py
+++ b/f1pred/features.py
@@ -1264,11 +1264,12 @@ def build_session_features(jc: JolpicaClient, om: OpenMeteoClient,
     # Current season weight boost
     boost = getattr(cfg.modelling.blending, "current_season_weight", 8.0)
     qual_boost = getattr(cfg.modelling.blending, "current_season_qualifying_weight", boost)
+    sprint_boost = getattr(cfg.modelling.blending, "current_season_sprint_weight", qual_boost)
     s_int = int(season)
 
     # Form indices
     form = compute_form_indices(hist, ref_date=ref_date, half_life_days=cfg.modelling.recency_half_life_days.base,
-                                current_season=s_int, boost_factor=boost, sprint_boost_factor=qual_boost)
+                               current_season=s_int, boost_factor=boost, sprint_boost_factor=sprint_boost)
 
     # Ensure 'session' column exists
     if 'session' not in hist.columns:
@@ -1378,7 +1379,7 @@ def build_session_features(jc: JolpicaClient, om: OpenMeteoClient,
         qual_form = pd.DataFrame(columns=["driverId", "qualifying_form_index"])
     try:
         sprint_form = compute_sprint_form(hist, ref_date=ref_date, half_life_days=cfg.modelling.recency_half_life_days.base,
-                                            current_season=s_int, sprint_boost_factor=qual_boost)
+                                           current_season=s_int, sprint_boost_factor=sprint_boost)
         logger.info(f"[features] Sprint form computed for {len(sprint_form)} drivers")
     except Exception as e:
         logger.info(f"[features] Sprint form failed: {e}")

--- a/f1pred/models.py
+++ b/f1pred/models.py
@@ -30,7 +30,8 @@ def build_hist_training_X(hist: 'pd.DataFrame', X_current: 'pd.DataFrame',
                           ref_date: 'datetime', half_life_days: int = 120,
                           max_events: int = 200,
                           boost_factor: float = 1.0,
-                          qual_boost_factor: float = 1.0) -> Optional['pd.DataFrame']:
+                          qual_boost_factor: float = 1.0,
+                          sprint_boost_factor: float = 1.0) -> Optional['pd.DataFrame']:
     """Build a lightweight training DataFrame from historical race results.
 
     Uses only columns that overlap with the current event feature matrix ``X_current``
@@ -189,14 +190,10 @@ def build_hist_training_X(hist: 'pd.DataFrame', X_current: 'pd.DataFrame',
         if np.any(is_p_cur_race):
             w[is_p_cur_race] *= boost_factor
 
-        # Boost current season sprints (use qual boost for sprints to match features.py)
-        # TODO: Sprint sessions are boosted with qual_boost_factor (current_season_
-        # qualifying_weight), but sprints are race-like sessions, not qualifying-like.
-        # A distinct sprint boost factor or using the race boost_factor may be more
-        # appropriate.  Requires further investigation and confirmation.
+        # Boost current season sprints
         is_p_cur_sprint = (p_season == s) & (p_sess == "sprint")
         if np.any(is_p_cur_sprint):
-            w[is_p_cur_sprint] *= qual_boost_factor
+            w[is_p_cur_sprint] *= sprint_boost_factor
 
         wval = p_val * w
         w_sum = np.bincount(p_dcodes, weights=w, minlength=n_drivers)

--- a/f1pred/predict.py
+++ b/f1pred/predict.py
@@ -946,7 +946,8 @@ def run_predictions_for_event(
                                 hist, X, ref_date,
                                 half_life_days=cfg.modelling.recency_half_life_days.base,
                                 boost_factor=getattr(cfg.modelling.blending, "current_season_weight", 8.0),
-                                qual_boost_factor=getattr(cfg.modelling.blending, "current_season_qualifying_weight", 20.0)
+                                qual_boost_factor=getattr(cfg.modelling.blending, "current_season_qualifying_weight", 20.0),
+                                sprint_boost_factor=getattr(cfg.modelling.blending, "current_season_sprint_weight", 8.0)
                             )
                         except Exception as e:
                             logger.info(f"[predict] Could not build historical training set: {e}")

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -69,6 +69,7 @@ class TestCalibrationManager(unittest.TestCase):
         for key in ("gbm_weight", "baseline_weight", "baseline_team_factor",
                      "grid_factor",
                      "current_season_weight", "current_season_qualifying_weight",
+                     "current_season_sprint_weight",
                      "current_quali_factor", "analytical_win_weight"):
             self.assertIn(key, b, f"Missing blending key: {key}")
 

--- a/tests/test_qualifying_weight.py
+++ b/tests/test_qualifying_weight.py
@@ -70,11 +70,11 @@ def test_build_hist_training_X_sprint_boost():
     hist = pd.DataFrame(hist_data)
     X_current = pd.DataFrame([{"driverId": "max", "form_index": 0.0}])
 
-    # With high qual_boost_factor, the sprint result should be boosted (lowering form_index)
-    res1 = build_hist_training_X(hist, X_current, base_date + timedelta(days=1), boost_factor=1.0, qual_boost_factor=1.0)
+    # With high sprint_boost_factor, the sprint result should be boosted (lowering form_index)
+    res1 = build_hist_training_X(hist, X_current, base_date + timedelta(days=1), boost_factor=1.0, qual_boost_factor=1.0, sprint_boost_factor=1.0)
     fi1 = res1[res1["grid"] == 5]["form_index"].iloc[0]
 
-    res2 = build_hist_training_X(hist, X_current, base_date + timedelta(days=1), boost_factor=1.0, qual_boost_factor=100.0)
+    res2 = build_hist_training_X(hist, X_current, base_date + timedelta(days=1), boost_factor=1.0, qual_boost_factor=100.0, sprint_boost_factor=100.0)
     fi2 = res2[res2["grid"] == 5]["form_index"].iloc[0]
 
     print(f"FI1: {fi1}, FI2: {fi2}")


### PR DESCRIPTION
I've successfully resolved TODO #3 by introducing a dedicated `current_season_sprint_weight` calibration parameter, decoupling sprint weighting from qualifying weighting.

### Changes Implemented:

1. **Configuration & Parameters**
   - Added `current_season_sprint_weight` (default `8.0`) to `BlendingCfg` in `f1pred/config.py`.
   - Updated `f1pred/calibrate.py` to include the new parameter at index `25` in `PARAM_NAMES`, `PARAM_BOUNDS`, and `PARAM_DEFAULTS`.
   - Updated `_unpack_weights` to extract the new parameter with a backward-compatibility fallback (`if len(w) > 25 else 8.0`) for legacy weight files.
   - Updated `_pack_weights` to append the new parameter.
   - The addition of this new parameter seamlessly alters the `CALIBRATION_VERSION` hash, triggering an automatic recalibration when the new version runs.

2. **Core Modelling**
   - Added `sprint_boost_factor` to `build_hist_training_X` signature in `f1pred/models.py`.
   - Replaced `qual_boost_factor` with `sprint_boost_factor` for boosting current-season sprints inside the `build_hist_training_X` array operations.
   - Removed the TODO block pointing out the sprint boosting discrepancy in `f1pred/models.py`.

3. **Feature Construction**
   - Added a `sprint_boost` local in `f1pred/features.py` fetching `current_season_sprint_weight`.
   - Wired `sprint_boost_factor=sprint_boost` into both `compute_form_indices` and `compute_sprint_form` when called from `build_session_features`.

4. **Prediction Orchestration**
   - Passed `sprint_boost_factor` resolving to the config's `current_season_sprint_weight` down to the `build_hist_training_X` call within `f1pred/predict.py`.

5. **Test Adjustments**
   - Extended the target set of blending keys in `tests/test_calibration.py::test_defaults_blending_complete` to assert `current_season_sprint_weight` existence.
   - Updated `test_build_hist_training_X_sprint_boost` in `tests/test_qualifying_weight.py` to use `sprint_boost_factor` over `qual_boost_factor` to appropriately assert sprint result inflation testing.
   - Confirmed the full pytest test suite passes efficiently.

Closes #421

<a href="https://opencode.ai/s/PuE8Bc6l"><img width="200" alt="New%20session%20-%202026-04-27T23%3A18%3A38.914Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA0LTI3VDIzOjE4OjM4LjkxNFo=.png?model=openrouter/google/gemini-3.1-pro-preview&version=1.14.28&id=PuE8Bc6l" /></a>
[opencode session](https://opencode.ai/s/PuE8Bc6l)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/2fst4u/f1predictor/actions/runs/25024733409)