### PR TITLE
🧹 Sweep: Remove unused get_db function

### DIFF
--- a/f1pred/database.py
+++ b/f1pred/database.py
@@ -28,13 +28,3 @@ def init_db(engine):
     Base.metadata.create_all(bind=engine)
     logger.info("Database tables initialized.")
 
-# Dependency to use in FastAPI routes
-def get_db(session_factory):
-    """Dependency that yields a database session."""
-    def _get_db():
-        db = session_factory()
-        try:
-            yield db
-        finally:
-            db.close()
-    return _get_db

--- a/f1pred/web.py
+++ b/f1pred/web.py
@@ -23,7 +23,7 @@ from .data.jolpica import JolpicaClient
 from .data.fastf1_backend import init_fastf1
 from .prediction_manager import PredictionManager
 
-from .database import get_engine, get_session_local, init_db, get_db
+from .database import get_engine, get_session_local, init_db
 from .models_db import User, Setting
 from .auth import verify_password, create_access_token, get_current_user_dependency, get_password_hash
 


### PR DESCRIPTION
💡 What: Removed the unused `get_db` function from `f1pred/database.py` and its corresponding unused import in `f1pred/web.py`.

🎯 Why: The function `get_db` in `database.py` was essentially dead code. The FastAPI dependency injection in `web.py` uses `Depends(get_db_session)` which is natively defined inside `web.py`. `get_db` from `database.py` was completely unreferenced.

🔬 Verification: 
- Ran `git grep "get_db"` which confirmed `get_db_session` was actively used in `web.py`, while `get_db` was merely imported but never called.
- Removed it and ran `python3 -m pytest tests/` which passed with no regressions (excluding known intermittent timeout/mocking errors for prediction_manager/predict).

---
*PR created automatically by Jules for task [16563912306747963959](https://jules.google.com/task/16563912306747963959) started by @2fst4u*