### PR TITLE
🎨 Palette: [UX improvement] explicitly associate form labels with inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-04 - Found unlinked form labels
+**Learning:** Found an accessibility issue pattern in the app's components where some form labels were not explicitly linked to their corresponding inputs using `for` and `id` attributes. This decreases screen reader support and general accessibility.
+**Action:** Applied `for` and `id` attributes to explicitly link labels with their inputs in `index.html`. Look for this pattern in future UI reviews.

--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -715,13 +715,13 @@
                                 <h3 class="text-sm font-medium text-gray-200 mb-3">Integrations (Coming Soon)</h3>
                                 <div class="bg-gray-900/50 p-5 rounded border border-gray-700 space-y-5 opacity-50 pointer-events-none">
                                     <div>
-                                        <label class="block text-sm font-medium text-gray-400 mb-1">LLM Server URL</label>
-                                        <input type="text" x-model="settings.llm_server_url" disabled
+                                        <label for="llm-server-url" class="block text-sm font-medium text-gray-400 mb-1">LLM Server URL</label>
+                                        <input id="llm-server-url" type="text" x-model="settings.llm_server_url" disabled
                                             class="block w-full bg-gray-800 border border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm text-white">
                                     </div>
                                     <div>
-                                        <label class="block text-sm font-medium text-gray-400 mb-1">LLM API Key</label>
-                                        <input type="password" x-model="settings.llm_api_key" disabled
+                                        <label for="llm-api-key" class="block text-sm font-medium text-gray-400 mb-1">LLM API Key</label>
+                                        <input id="llm-api-key" type="password" x-model="settings.llm_api_key" disabled
                                             class="block w-full bg-gray-800 border border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm text-white">
                                     </div>
                                 </div>


### PR DESCRIPTION
**💡 What:**
Added explicit `for` and `id` attributes to pair the "LLM Server URL" and "LLM API Key" `<label>`s with their respective `<input>`s in the application settings panel.

**🎯 Why:**
This is a standard accessibility best practice. Before this change, the labels were completely disassociated from the input elements from the perspective of assistive technologies like screen readers. Establishing this pattern allows for automated testing to find inputs `get_by_label()`, correctly announces context for visually impaired users, and expands the click target area (clicking the label focuses the input).

**📸 Before/After:**
*Before:*
```html
<label class="block ...">LLM Server URL</label>
<input type="text" x-model="..." ...>
```
*After:*
```html
<label for="llm-server-url" class="block ...">LLM Server URL</label>
<input id="llm-server-url" type="text" x-model="..." ...>
```

**♿ Accessibility:**
Improves screen reader compatibility and keyboard navigation target confidence for these form controls. Explicitly associating form controls adheres to WCAG guidelines.

**🔬 Verification:**
- Ran `pytest` unit tests (11/11 passed).
- Playwright frontend verification successfully navigated to settings and captured the element states.
- Logged pattern to `.jules/palette.md`.

---
*PR created automatically by Jules for task [15566871186942977991](https://jules.google.com/task/15566871186942977991) started by @2fst4u*