### PR TITLE
📚 Archivist: [Clarify] Feature Labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The model uses a variety of engineered features to capture driver talent, car pe
 - **Sprint Session (`is_sprint`)**: A boolean flag indicating if the session is a sprint.
 - **Grid Position (`grid`)**: The starting position for the race. This acts as a mathematical "anchor" for race predictions.
 - **Quali Position (`current_quali_pos`)**: The actual qualifying result achieved during the current race weekend.
+- **Constructor (`constructorId`)**: The constructor (team) identifier for the given entry.
 
 ### Weather & Conditions
 - **Weather Impact (`weather_effect`)**: The total predicted influence of atmospheric conditions on a driver's performance.

--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -1479,6 +1479,8 @@
                 _featureLabels: {
                     form_index: 'Race Form',
                     qualifying_form_index: 'Quali Form',
+                    sprint_form_index: 'Sprint Form',
+                    sprint_qualifying_form_index: 'Sprint Quali Form',
                     team_form_index: 'Team Strength',
                     teammate_delta: 'vs Teammate',
                     grid_finish_delta: 'Overtaking Skill',


### PR DESCRIPTION
💡 Problem: 
The UI template `index.html` was missing feature label mappings for sprint session form variables (`sprint_form_index` and `sprint_qualifying_form_index`), leading to a fallback visual presentation. Additionally, `README.md` was missing documentation for `constructorId`, although it is processed by the model and displayed in the UI.

🎯 Fix: 
1. Added `sprint_form_index: 'Sprint Form'` and `sprint_qualifying_form_index: 'Sprint Quali Form'` to `_featureLabels` in `f1pred/templates/index.html`.
2. Added `- **Constructor (\`constructorId\`)**: The constructor (team) identifier for the given entry.` to the `Session & Grid` section in `README.md`.

🧪 Verification: 
- Ran targeted tests: `pytest tests/test_ui_fix.py`, `pytest tests/test_ui_layout.py`, `pytest tests/test_models.py`, `pytest tests/test_features.py` which all passed.

🔎 Scope: 
This PR contains only UI template feature label mapping additions and a README documentation update. No application business logic has been changed.

---
*PR created automatically by Jules for task [12150602404162707654](https://jules.google.com/task/12150602404162707654) started by @2fst4u*