### PR TITLE
🧹 Sweep: Remove unused variables and imports

### DIFF
--- a/.jules/sweep.md
+++ b/.jules/sweep.md
@@ -9,3 +9,7 @@
 ## 2025-03-24 - Remove leftover visual verification and UI test runner scripts
 **Learning:** Playwright UI test runner scripts (e.g., `verify_settings.py`) used for manual verification of settings screens and screenshots left behind from visual layout testing (e.g., `mobile_optimized_verified.png`) are sometimes accidentally tracked or left in the repository root. These are not used in the application.
 **Action:** Always scan the root directory for `*.png` visual verification images or ad-hoc `verify_*.py` debug scripts, ensure they are unreferenced via `git grep`, and remove them to prevent workspace bloat.
+
+## 2025-04-12 - Using static analysis tools for unused variables and imports
+**Learning:** Tools like vulture can find many unused variables and imports that are left behind after refactoring, however you must be careful to verify that the tool's suggestions are actually correct and not false positives.
+**Action:** Always run tools like vulture to search for orphaned or unused code across the entire codebase to quickly find cleanup opportunities, then manually verify using `grep` before removing anything.

--- a/f1pred/auth.py
+++ b/f1pred/auth.py
@@ -13,7 +13,6 @@ from .models_db import User
 
 SECRET_KEY = os.environ.get("F1PRED_SECRET_KEY", secrets.token_urlsafe(32))
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24 * 7  # 1 week
 
 # Configure CryptContext for password hashing using bcrypt.
 # Disable truncate_error (which raises ValueError for passwords > 72 bytes)

--- a/f1pred/models.py
+++ b/f1pred/models.py
@@ -92,7 +92,7 @@ def build_hist_training_X(hist: 'pd.DataFrame', X_current: 'pd.DataFrame',
         races_cons_full = np.array([None] * len(races_full))
 
     team_ids_full = races_cons_full
-    t_codes_full, t_uniques = pd.factorize(team_ids_full)
+    _, t_uniques = pd.factorize(team_ids_full)
     n_teams = len(t_uniques)
 
     # Map races finishes back to team codes
@@ -306,7 +306,7 @@ def build_hist_training_X(hist: 'pd.DataFrame', X_current: 'pd.DataFrame',
 
 
                 valid_q = wq_sum > 0
-                q_form_index[valid_q] = wval_sum_val = wqval_sum[valid_q] / np.maximum(wq_sum[valid_q], 1e-6)
+                q_form_index[valid_q] = wqval_sum[valid_q] / np.maximum(wq_sum[valid_q], 1e-6)
                 tm_delta_index[valid_q] = wqdelta_sum[valid_q] / np.maximum(wq_sum[valid_q], 1e-6)
 
                 # --- Calculate sprint_qualifying_form_index ---

--- a/tests/test_ui_fix.py
+++ b/tests/test_ui_fix.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 try:
-    from playwright.sync_api import Page, expect
+    from playwright.sync_api import Page
     HAS_PLAYWRIGHT = True
 except ImportError:
     HAS_PLAYWRIGHT = False

--- a/tests/test_ui_layout.py
+++ b/tests/test_ui_layout.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 try:
-    from playwright.sync_api import Page, expect
+    from playwright.sync_api import Page
     HAS_PLAYWRIGHT = True
 except ImportError:
     HAS_PLAYWRIGHT = False


### PR DESCRIPTION
💡 **What:**
- Removed `t_codes_full` and `wval_sum_val` variable assignments in `f1pred/models.py`.
- Removed `ACCESS_TOKEN_EXPIRE_MINUTES` constant in `f1pred/auth.py`.
- Removed `expect` from the `playwright.sync_api` imports in `tests/test_ui_fix.py` and `tests/test_ui_layout.py`.

🎯 **Why:** 
- The variables and constant were defined but never referenced anywhere else in the code, leaving behind unused declarations.
- The `expect` import from Playwright was present but not used in the UI test files.
- Removing these unused assets helps reduce repository bloat, prevents cognitive overload, and conforms with the philosophy of "Less code is better code".

🔬 **Verification:**
- Ran global workspace text searches (`grep -rn ...`) to guarantee these variables and imports were completely unreferenced and safe to remove.
- Verified removal via `make test` and running the test suite (`python -m pytest tests/test_ui_fix.py tests/test_ui_layout.py`) locally; no tests were broken.

---
*PR created automatically by Jules for task [13726726784868067012](https://jules.google.com/task/13726726784868067012) started by @2fst4u*