### PR TITLE
📚 Archivist: Clarify local testing dependencies in README

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -3,8 +3,8 @@
 **Action:** When auditing configuration options, cross-reference `config.yaml` values explicitly against the `README.md` to spot undocumented parameters (like `precipitation_unit`).
 
 ## 2024-03-10 - Test Dependency Drift
-**Learning:** The development environment requires manual installation of test and runtime tools (`playwright`, `fastparquet`, `pyarrow`, `colorama`) beyond the base dependencies in `requirements.txt`. The `README.md` instructions frequently drift from the actual required sequence, specifically omitting the browser binary installation required by `pytest-playwright`.
-**Action:** When updating test instructions, ensure the sequence explicitly includes `make install` followed by the manual installation of all test dependencies (including `playwright install --with-deps chromium`) before running `make test`.
+**Learning:** The development environment requires manual installation of test and runtime tools (`pytest-playwright`, `pytest-asyncio`, `fastparquet`, `pyarrow`, `colorama`) beyond the base dependencies in `requirements.txt`. The `README.md` instructions frequently drift from the actual required sequence, specifically omitting the browser binary installation required by `pytest-playwright` and missing `pytest-playwright` and `pytest-asyncio` themselves. Missing `pytest-playwright` but having `playwright` installed crashes local tests with a missing `page` fixture error.
+**Action:** When updating test instructions, ensure the sequence explicitly includes `make install` followed by the manual installation of all test dependencies (including `pytest-playwright`, `pytest-asyncio`, and `playwright install --with-deps chromium`) before running `make test`.
 
 ## 2026-03-22 - Variable Glossary Drift
 **Learning:** Model features and their internal keys (`form_index`, `teammate_delta`, etc.) frequently evolve in `f1pred/features.py` and `f1pred/predict.py` without corresponding updates in `README.md`, causing documentation to become vague or outdated.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Run the local test suite (requires installing test dependencies first):
 
 ```bash
 make install
-pip install pytest pytest-cov httpx playwright fastparquet pyarrow colorama
+pip install pytest pytest-cov pytest-asyncio pytest-playwright httpx playwright fastparquet pyarrow colorama
 playwright install --with-deps chromium
 make test
 ```


### PR DESCRIPTION
💡 Problem: The testing instructions in `README.md` directed users to install `playwright` but omitted `pytest-playwright` and `pytest-asyncio`. This causes local test suites to crash because pytest cannot resolve the `page` fixture for UI tests, failing before the `HAS_PLAYWRIGHT` skip condition can even be evaluated.

🎯 Fix: Updated the `pip install` sequence in `README.md` to explicitly include `pytest-playwright` and `pytest-asyncio`. Added a journal entry in `.jules/archivist.md` documenting this test environment constraint.

🧪 Verification: Ran `pytest tests/test_ui_fix.py` without `pytest-playwright` and confirmed the `fixture 'page' not found` crash. Installed `pytest-playwright` and `pytest-asyncio` as documented and confirmed the tests execute and pass correctly.

🔎 Scope: This PR contains ONLY documentation changes to `README.md` and `.jules/archivist.md`.

---
*PR created automatically by Jules for task [7377408608632336327](https://jules.google.com/task/7377408608632336327) started by @2fst4u*