### PR TITLE
Update Claude workflow prompt to include blocking instructions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,7 +41,7 @@ jobs:
             actions: read
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          prompt: "Implement the issue and open a pull request when done."
+          prompt: "Implement the issue and open a pull request when done. If you cannot proceed (e.g. prerequisites are not yet complete, or the scope is unclear), post a comment on the issue explaining what is blocking you."
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## Summary

- Updated the `prompt` field in `.github/workflows/claude.yml` to instruct Claude to post a comment on the issue when it cannot proceed, rather than failing silently.

## Change

**Before:**
```
Implement the issue and open a pull request when done.
```

**After:**
```
Implement the issue and open a pull request when done. If you cannot proceed (e.g. prerequisites are not yet complete, or the scope is unclear), post a comment on the issue explaining what is blocking you.
```

## Test plan
- [ ] Trigger the Claude workflow on an issue that is intentionally ambiguous or has unmet prerequisites
- [ ] Verify Claude posts a blocking comment instead of failing silently

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUGM2brhRjYj8WAbZzu8cs)_