### PR TITLE
🎨 Palette: Add ARIA roles to navigation tabs

### DIFF
--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -173,13 +173,21 @@
 
         <!-- Navigation Tabs -->
         <div class="max-w-[1400px] mx-auto px-2 sm:px-4 mb-4 mt-4">
-            <div class="flex space-x-6 border-b border-gray-700">
+            <div class="flex space-x-6 border-b border-gray-700" role="tablist" aria-label="Main Navigation">
                 <button @click="activeTab = 'predictions'"
+                    id="tab-predictions"
+                    role="tab"
+                    aria-controls="panel-predictions"
+                    :aria-selected="activeTab === 'predictions'"
                     :class="activeTab === 'predictions' ? 'border-red-500 text-white' : 'border-transparent text-gray-400 hover:text-gray-300'"
                     class="py-2 px-1 border-b-2 font-medium text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded">
                     Predictions
                 </button>
                     <button @click="activeTab = 'settings'"
+                    id="tab-settings"
+                    role="tab"
+                    aria-controls="panel-settings"
+                    :aria-selected="activeTab === 'settings'"
                     :class="activeTab === 'settings' ? 'border-red-500 text-white' : 'border-transparent text-gray-400 hover:text-gray-300'"
                     class="py-2 px-3 border-b-2 font-medium text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded-t-md transition-colors duration-200">
                     Settings
@@ -187,7 +195,7 @@
             </div>
         </div>
 
-        <main class="max-w-[1400px] w-full mx-auto px-4 py-6 md:px-8 md:py-8" x-show="activeTab === 'predictions'">
+        <main id="panel-predictions" role="tabpanel" aria-labelledby="tab-predictions" class="max-w-[1400px] w-full mx-auto px-4 py-6 md:px-8 md:py-8" x-show="activeTab === 'predictions'">
             <!-- Controls -->
             <div class="card p-5 md:p-8 mb-6 md:mb-8 shadow-xl">
                 <div class="flex flex-col gap-4">
@@ -628,7 +636,7 @@
         </main>
 
         <!-- Settings View -->
-        <main class="max-w-[1400px] w-full mx-auto px-4 py-6 md:px-8 md:py-8" x-show="activeTab === 'settings'" style="display: none;">
+        <main id="panel-settings" role="tabpanel" aria-labelledby="tab-settings" class="max-w-[1400px] w-full mx-auto px-4 py-6 md:px-8 md:py-8" x-show="activeTab === 'settings'" style="display: none;">
             <div class="bg-gray-800 rounded-lg p-6 border border-gray-700 max-w-2xl">
                 <h2 class="text-xl font-bold mb-6 text-white border-b border-gray-700 pb-2">Application Settings</h2>
 


### PR DESCRIPTION
💡 **What:** Added standard ARIA tab roles (`tablist`, `tab`, `tabpanel`) and relationship attributes (`aria-controls`, `aria-labelledby`, `aria-selected`) to the main navigation tabs ("Predictions" and "Settings") in the F1 Outcome Predictor UI.

🎯 **Why:** The main navigation was relying on styled `div` and `button` elements without semantic structure. This made it difficult for screen reader users to understand the relationship between the tabs and the content panels, or to know which tab was currently active.

📸 **Before/After:** The visual appearance is identical, but the underlying accessibility tree is now properly structured as a tab interface.

♿ **Accessibility:**
- Added `role="tablist"` to the container.
- Added `role="tab"`, `id`, `aria-controls`, and dynamically bound `:aria-selected` to the tab buttons.
- Added `role="tabpanel"`, `id`, and `aria-labelledby` to the corresponding `<main>` content sections.
- Improves context and navigation for assistive technologies.

---
*PR created automatically by Jules for task [1411822958550156640](https://jules.google.com/task/1411822958550156640) started by @2fst4u*