### PR TITLE
🛡️ Sentinel: [HIGH] Add rate limiting to login endpoint

### DIFF
--- a/f1pred/web.py
+++ b/f1pred/web.py
@@ -10,6 +10,8 @@ import math
 import threading
 import queue
 import httpx
+from collections import defaultdict
+import time
 from fastapi import FastAPI, Request, Query, Path, HTTPException, Depends
 from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
@@ -78,6 +80,7 @@ def _sanitize_for_json(v: Any, _math: Any = math) -> Any:
 app = FastAPI(title="F1 Prediction Web UI")
 _config: AppConfig = None
 _prediction_manager: Optional[PredictionManager] = None
+_login_attempts = defaultdict(list)
 
 @app.middleware("http")
 async def add_security_headers(request: Request, call_next):
@@ -487,9 +490,25 @@ async def predictions_latest():
 
 @app.post("/api/auth/token")
 async def login_for_access_token(
+    request: Request,
     form_data: OAuth2PasswordRequestForm = Depends(),
     db: Session = Depends(get_db_session)
 ):
+    # 🛡️ Sentinel: Add rate limiting to prevent brute-force attacks
+    client_ip = request.client.host if request.client else "unknown"
+    now = time.time()
+
+    # Clean up old attempts (60 second window)
+    _login_attempts[client_ip] = [t for t in _login_attempts[client_ip] if now - t < 60]
+
+    if len(_login_attempts[client_ip]) >= 10:
+        raise HTTPException(
+            status_code=429,
+            detail="Too many login attempts. Please try again later."
+        )
+
+    _login_attempts[client_ip].append(now)
+
     user = db.query(User).filter(User.username == form_data.username).first()
     if not user or not verify_password(form_data.password, user.hashed_password):
         raise HTTPException(

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -55,3 +55,16 @@ def test_webhook_ssrf_protection_non_discord(client_with_auth):
 def test_webhook_ssrf_protection_startswith_bypass(client_with_auth):
     response = client_with_auth.post("/api/settings/test-webhook", json={"url": "https://discord.com@127.0.0.1:80/api/webhooks/"})
     assert response.status_code == 400
+
+def test_login_rate_limiting(client):
+    # Send 10 failed login attempts
+    for _ in range(10):
+        response = client.post("/api/auth/token", data={"username": "admin", "password": "wrongpassword"})
+        if response.status_code == 429:
+            break # Stop if rate limit already hit from other tests
+        assert response.status_code == 401
+
+    # The next attempt should be rate limited
+    response = client.post("/api/auth/token", data={"username": "admin", "password": "wrongpassword"})
+    assert response.status_code == 429
+    assert "Too many login attempts" in response.json()["detail"]


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `/api/auth/token` endpoint did not have any rate limiting mechanism, allowing an attacker to perform unlimited brute-force password guessing attacks against user accounts.
🎯 **Impact:** An attacker could systematically try thousands of passwords to compromise user accounts (such as the default `admin` account).
🔧 **Fix:** Implemented an in-memory rate limiter using `collections.defaultdict` to track login attempts per client IP. If an IP exceeds 10 attempts within a 60-second window, the server returns an HTTP `429 Too Many Requests` error.
✅ **Verification:** Verified by running the entire test suite and explicitly executing the newly added `test_login_rate_limiting` test in `tests/test_web_security.py` which guarantees a 429 status response.

---
*PR created automatically by Jules for task [1552081022125557269](https://jules.google.com/task/1552081022125557269) started by @2fst4u*