### PR TITLE
📚 Archivist: Clarify Atmospheric Data variables in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The model uses a variety of engineered features to capture driver talent, car pe
 - **Weather Impact (`weather_effect`)**: The total predicted influence of atmospheric conditions on a driver's performance.
 - **Condition Sensitivities (`weather_beta_temp`, `weather_beta_pressure`, `weather_beta_wind`, `weather_beta_rain`)**: Driver-specific sensitivity coefficients used to calculate the overall weather impact.
 - **Condition Skills (`temp_skill`, `rain_skill`, `wind_skill`, `pressure_skill`)**: Driver-specific proficiency scores for various weather conditions, derived from historical performance correlations.
-- **Atmospheric Data (`weather_temp_mean`, `weather_rain_sum`, etc.)**: Raw metrics (temperature, rain, wind, pressure, humidity) for the session window.
+- **Atmospheric Data (`weather_temp_mean`, `weather_rain_sum`, `weather_wind_mean`, `weather_pressure_mean`, `weather_humidity_mean`)**: Raw metrics (temperature, rain, wind, pressure, humidity) for the session window.
 
 ## Configuration
 


### PR DESCRIPTION
💡 Problem
The "Input Variables" section of the README listed `weather_temp_mean` and `weather_rain_sum`, but used a vague `etc.` for the rest of the variables, which drifted from the actual keys (`weather_wind_mean`, `weather_pressure_mean`, `weather_humidity_mean`) used in `predict.py`'s `_FEATURE_LABELS` and `templates/index.html`.

🎯 Fix
Replaced the ambiguous `etc.` with the explicit list of actual atmospheric variable keys (`weather_wind_mean`, `weather_pressure_mean`, `weather_humidity_mean`) used in the model. 

🧪 Verification
Ran `make test` locally to ensure no files were broken by this change and verified the documentation explicitly matches `f1pred/predict.py`.

🔎 Scope
This PR contains ONLY documentation changes to `README.md`. No application code or workflows were altered.

---
*PR created automatically by Jules for task [7729118022529660448](https://jules.google.com/task/7729118022529660448) started by @2fst4u*