### PR TITLE
Test suite audit: fix latent calibration bug, add missing coverage, prune superficial tests

### DIFF
--- a/f1pred/calibrate.py
+++ b/f1pred/calibrate.py
@@ -977,7 +977,7 @@ class CalibrationManager:
 
             # Convert to nested structure
             self.current_weights = _unpack_weights(w_opt)
-            self.current_weights["objective_score"] = float(res.fun)
+            self.current_weights["objective_score"] = float(best_res.fun)
 
             self.save_weights()
             duration = time.time() - t0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,6 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 66.50
+fail_under = 73.00
 show_missing = true
 precision = 2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,15 +35,21 @@ def sample_roster():
 
 @pytest.fixture
 def sample_features():
-    """Generate sample feature matrix."""
+    """Generate sample feature matrix.
+
+    Uses a seeded RNG so tests that assert on prediction ordering/variance
+    (e.g. test_models.test_pace_model_order_makes_sense) are deterministic
+    rather than occasionally flaky.
+    """
     n_drivers = 20
+    rng = np.random.default_rng(1234)
     return pd.DataFrame({
         'driverId': [f'driver_{i}' for i in range(n_drivers)],
         'constructorId': [f'team_{i//2}' for i in range(n_drivers)],
-        'form_index': np.random.randn(n_drivers),
-        'team_form_index': np.random.randn(n_drivers),
-        'weather_beta_temp': np.random.randn(n_drivers) * 0.1,
-        'weather_beta_rain': np.random.randn(n_drivers) * 0.1,
+        'form_index': rng.standard_normal(n_drivers),
+        'team_form_index': rng.standard_normal(n_drivers),
+        'weather_beta_temp': rng.standard_normal(n_drivers) * 0.1,
+        'weather_beta_rain': rng.standard_normal(n_drivers) * 0.1,
         'session_type': ['race'] * n_drivers,
     })
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,135 @@
+"""Unit tests for f1pred.auth.
+
+auth.py was effectively untested: password verification, the deliberate
+72-byte bcrypt truncation, JWT creation/expiry, and the get_current_user
+401 branches (invalid token, missing ``sub``, unknown user) had no coverage.
+These tests exercise the primitives directly against an in-memory SQLite DB.
+"""
+import asyncio
+from datetime import timedelta
+
+import pytest
+from jose import jwt
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from fastapi import HTTPException
+
+from f1pred import auth
+from f1pred.database import Base
+from f1pred.models_db import User
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = Session()
+    db.add(User(username="alice", hashed_password=auth.get_password_hash("s3cret")))
+    db.commit()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# --------------------------------------------------------------------------
+# Password hashing / verification
+# --------------------------------------------------------------------------
+
+class TestPasswordHashing:
+    def test_hash_is_not_plaintext(self):
+        h = auth.get_password_hash("hunter2")
+        assert h != "hunter2"
+        assert h.startswith("$2")  # bcrypt prefix
+
+    def test_correct_password_verifies(self):
+        h = auth.get_password_hash("correct horse")
+        assert auth.verify_password("correct horse", h) is True
+
+    def test_wrong_password_rejected(self):
+        h = auth.get_password_hash("correct horse")
+        assert auth.verify_password("battery staple", h) is False
+
+    def test_passwords_truncated_at_72_bytes(self):
+        """Bcrypt only considers the first 72 bytes; auth.py truncates to match.
+
+        Two passwords sharing a 72-byte prefix must verify interchangeably
+        rather than raising on the >72-byte input.
+        """
+        prefix = "a" * 72
+        h = auth.get_password_hash(prefix + "EXTRA-IGNORED")
+        assert auth.verify_password(prefix + "different-tail", h) is True
+
+    def test_differing_within_72_bytes_rejected(self):
+        h = auth.get_password_hash("a" * 71 + "X")
+        assert auth.verify_password("a" * 71 + "Y", h) is False
+
+
+# --------------------------------------------------------------------------
+# JWT creation
+# --------------------------------------------------------------------------
+
+class TestAccessToken:
+    def test_token_round_trips_subject(self):
+        token = auth.create_access_token({"sub": "alice"})
+        payload = jwt.decode(token, auth.SECRET_KEY, algorithms=[auth.ALGORITHM])
+        assert payload["sub"] == "alice"
+        assert "exp" in payload
+
+    def test_custom_expiry_is_honoured(self):
+        short = auth.create_access_token({"sub": "alice"}, expires_delta=timedelta(seconds=1))
+        long = auth.create_access_token({"sub": "alice"}, expires_delta=timedelta(hours=1))
+        exp_short = jwt.decode(short, auth.SECRET_KEY, algorithms=[auth.ALGORITHM])["exp"]
+        exp_long = jwt.decode(long, auth.SECRET_KEY, algorithms=[auth.ALGORITHM])["exp"]
+        assert exp_long > exp_short
+
+
+# --------------------------------------------------------------------------
+# get_current_user dependency
+# --------------------------------------------------------------------------
+
+def _resolve_user(db, token):
+    get_current_user = auth.get_current_user_dependency(lambda: db)
+    return asyncio.run(get_current_user(token=token, db=db))
+
+
+class TestGetCurrentUser:
+    def test_valid_token_returns_user(self, db_session):
+        token = auth.create_access_token({"sub": "alice"})
+        user = _resolve_user(db_session, token)
+        assert user.username == "alice"
+
+    def test_invalid_token_raises_401(self, db_session):
+        with pytest.raises(HTTPException) as exc:
+            _resolve_user(db_session, "not.a.jwt")
+        assert exc.value.status_code == 401
+
+    def test_expired_token_raises_401(self, db_session):
+        token = auth.create_access_token({"sub": "alice"}, expires_delta=timedelta(seconds=-1))
+        with pytest.raises(HTTPException) as exc:
+            _resolve_user(db_session, token)
+        assert exc.value.status_code == 401
+
+    def test_missing_subject_raises_401(self, db_session):
+        token = auth.create_access_token({"sub": None})
+        with pytest.raises(HTTPException) as exc:
+            _resolve_user(db_session, token)
+        assert exc.value.status_code == 401
+
+    def test_unknown_user_raises_401(self, db_session):
+        token = auth.create_access_token({"sub": "ghost"})
+        with pytest.raises(HTTPException) as exc:
+            _resolve_user(db_session, token)
+        assert exc.value.status_code == 401
+
+    def test_token_signed_with_wrong_key_raises_401(self, db_session):
+        forged = jwt.encode({"sub": "alice"}, "attacker-key", algorithm=auth.ALGORITHM)
+        with pytest.raises(HTTPException) as exc:
+            _resolve_user(db_session, forged)
+        assert exc.value.status_code == 401

--- a/tests/test_calibration_run.py
+++ b/tests/test_calibration_run.py
@@ -1,0 +1,221 @@
+"""End-to-end exercise of CalibrationManager.run_calibration.
+
+The optimisation core in calibrate.py (run_calibration + the nested objective
+function — ~570 lines) was previously untested: no test ever invoked
+run_calibration, so the module sat at ~22% coverage and a latent NameError
+(``res.fun`` instead of ``best_res.fun`` at the point where the optimised
+objective score is stored) went undetected because it was swallowed by the
+broad ``except Exception`` around the whole routine.
+
+These tests drive the real objective function and optimiser over a small
+synthetic dataset, mocking only the expensive feature-building and
+GBM-training steps and capping the L-BFGS-B iteration count (the goal is to
+execute the per-event z-scoring, ensemble blending, Spearman/podium loss,
+regularisation, and the final weight-pack + persistence path — not to verify
+optimisation quality). The full calibration is run once per module via a
+shared fixture to keep the suite fast.
+"""
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.optimize as _sciopt
+
+from f1pred.calibrate import CalibrationManager
+
+
+# --- minimal config object -------------------------------------------------
+
+class _CalCfg:
+    enabled = True
+    lookback_window_days = 365
+    frequency_hours = 24
+
+    def __init__(self, weights_file):
+        self.weights_file = weights_file
+
+
+class _RecencyCfg:
+    base = 120.0
+    team = 240.0
+
+
+class _ModellingCfg:
+    recency_half_life_days = _RecencyCfg()
+
+
+class _Cfg:
+    def __init__(self, weights_file):
+        self.calibration = _CalCfg(weights_file)
+        self.modelling = _ModellingCfg()
+
+
+# --- synthetic history -----------------------------------------------------
+
+_DRIVERS = [f"drv_{i}" for i in range(8)]
+_TEAMS = [f"team_{i // 2}" for i in range(8)]
+
+
+def _event_rows(season, rnd, date, session):
+    """One event worth of finishing-order rows for all 8 drivers."""
+    rows = []
+    for pos, (drv, team) in enumerate(zip(_DRIVERS, _TEAMS), start=1):
+        rows.append({
+            "season": season,
+            "round": rnd,
+            "date": date,
+            "session": session,
+            "driverId": drv,
+            "constructorId": team,
+            "circuitId": f"circuit_{rnd}",
+            "position": float(pos),
+            "qpos": float(pos),
+            "grid": float(pos),
+            "points": max(0.0, 26.0 - pos),
+            "status": "Finished",
+        })
+    return rows
+
+
+def _make_history(now):
+    """Older training races (pre-window) + recent calibration races/quali."""
+    rows = []
+    # Training data well before the lookback window (~2 years back).
+    for r in range(1, 11):
+        d = now - timedelta(days=730 - r * 20)
+        rows += _event_rows(2024, r, d, "race")
+        rows += _event_rows(2024, r, d, "qualifying")
+    # Calibration data inside the 365-day window.
+    for r in range(1, 7):
+        d = now - timedelta(days=300 - r * 40)
+        rows += _event_rows(2025, r, d, "race")
+        rows += _event_rows(2025, r, d, "qualifying")
+    df = pd.DataFrame(rows)
+    df["date"] = pd.to_datetime(df["date"], utc=True)
+    return df
+
+
+def _fake_features(*args, **kwargs):
+    """Stand-in for build_session_features: returns (X, meta, roster).
+
+    Signature in source: build_session_features(jc, om, season, round,
+    session, date, cfg).
+    """
+    X = pd.DataFrame({
+        "driverId": _DRIVERS,
+        "constructorId": _TEAMS,
+        "form_index": np.linspace(-1.0, 1.0, len(_DRIVERS)),
+        "team_form_index": np.linspace(-0.5, 0.5, len(_DRIVERS)),
+        "grid": np.arange(1, len(_DRIVERS) + 1, dtype=float),
+    })
+    return X, {"raceName": "Synthetic GP"}, X[["driverId", "constructorId"]]
+
+
+class _FakePipe:
+    """GBM stand-in whose prediction tracks grid (so it correlates with truth)."""
+
+    def predict(self, X):
+        if isinstance(X, pd.DataFrame) and "grid" in X.columns:
+            return np.asarray(X["grid"], dtype=float)
+        return np.zeros(len(X), dtype=float)
+
+
+def _fake_train_pace_model(X_train, session, cfg, *a, **k):
+    features = ["grid", "form_index", "team_form_index"]
+    return _FakePipe(), None, features, None
+
+
+_real_minimize = _sciopt.minimize
+
+
+def _fast_minimize(fun, x0, **kwargs):
+    """Wrap scipy.optimize.minimize with a tiny iteration cap for speed.
+
+    The default calibration runs L-BFGS-B with maxiter=800 over 26 params x 5
+    starts, which takes minutes. The tests only need the code path executed,
+    so we cap iterations hard. (run_calibration uses a local
+    ``from scipy.optimize import minimize`` that resolves the patched attr.)
+    """
+    options = {**kwargs.get("options", {}), "maxiter": 3}
+    kwargs["options"] = options
+    return _real_minimize(fun, x0, **kwargs)
+
+
+def _run_full_calibration(cm):
+    now = datetime.now(timezone.utc)
+    hist = _make_history(now)
+    with patch("f1pred.features.build_session_features", side_effect=_fake_features), \
+         patch("f1pred.models.train_pace_model", side_effect=_fake_train_pace_model), \
+         patch("scipy.optimize.minimize", side_effect=_fast_minimize):
+        cm.run_calibration(jc=object(), om=object(), history_df=hist)
+    return cm
+
+
+@pytest.fixture(scope="module")
+def calibrated(tmp_path_factory):
+    """Run a full (iteration-capped) calibration once and share the result."""
+    weights_file = tmp_path_factory.mktemp("cal") / "weights.json"
+    cm = CalibrationManager(_Cfg(str(weights_file)))
+    return _run_full_calibration(cm)
+
+
+def test_run_calibration_stores_finite_objective_score(calibrated):
+    """Regression guard for the res.fun NameError.
+
+    On a successful run the optimised objective value must be written into
+    current_weights. Before the fix this raised NameError (res undefined),
+    was swallowed by the broad except, and objective_score was never set.
+    """
+    assert "objective_score" in calibrated.current_weights, (
+        "run_calibration did not store objective_score — the final weight-write "
+        "path failed (regression of the res.fun/best_res.fun bug)."
+    )
+    assert np.isfinite(calibrated.current_weights["objective_score"])
+
+
+def test_run_calibration_persists_weights_and_metadata(calibrated):
+    """A successful run saves weights with version + last_race_id to disk."""
+    assert Path(calibrated.weights_file).exists()
+    # last_race_id is set from the final event in the lookback window.
+    assert calibrated.last_race_id == "2025_6"
+
+    reloaded = CalibrationManager(_Cfg(str(calibrated.weights_file)))
+    data = reloaded.load_weights()
+    assert "calibration_version" in data
+    assert "calibration_timestamp" in data
+    # All six tunable groups survive the optimisation + round-trip.
+    for group in ("ensemble", "blending", "dnf", "simulation", "recency", "elo"):
+        assert group in data
+
+
+def test_run_calibration_keeps_ensemble_weights_normalised(calibrated):
+    """Optimised race + qualifying ensemble weights are each renormalised to ~1."""
+    ens = calibrated.current_weights["ensemble"]
+    race_total = ens["w_gbm"] + ens["w_elo"] + ens["w_bt"] + ens["w_mixed"]
+    quali_total = (ens["w_gbm_quali"] + ens["w_elo_quali"]
+                   + ens["w_bt_quali"] + ens["w_mixed_quali"])
+    assert race_total == pytest.approx(1.0, abs=1e-5)
+    assert quali_total == pytest.approx(1.0, abs=1e-5)
+
+
+def test_run_calibration_aborts_cleanly_with_no_recent_races(tmp_path):
+    """No races in the lookback window -> early return, defaults untouched."""
+    cm = CalibrationManager(_Cfg(str(tmp_path / "weights.json")))
+    now = datetime.now(timezone.utc)
+    old_rows = []
+    for r in range(1, 4):
+        old_rows += _event_rows(2020, r, now - timedelta(days=1500 + r), "race")
+    hist = pd.DataFrame(old_rows)
+    hist["date"] = pd.to_datetime(hist["date"], utc=True)
+
+    with patch("f1pred.features.build_session_features", side_effect=_fake_features), \
+         patch("f1pred.models.train_pace_model", side_effect=_fake_train_pace_model), \
+         patch("scipy.optimize.minimize", side_effect=_fast_minimize):
+        cm.run_calibration(jc=object(), om=object(), history_df=hist)
+
+    # Aborted before optimisation: no objective score recorded, file not written.
+    assert "objective_score" not in cm.current_weights
+    assert not Path(cm.weights_file).exists()

--- a/tests/test_ensemble_quali.py
+++ b/tests/test_ensemble_quali.py
@@ -1,0 +1,86 @@
+"""Tests for the qualifying weight path and z-normalisation in combine_pace.
+
+The audit found that combine_pace was only ever exercised with the default
+race weights: the qualifying branch (session_type in {"qualifying",
+"sprint_qualifying"}), which selects the dedicated *_quali weights — the whole
+reason that weight set exists — had no coverage, nor did the zero-variance /
+zero-weight fallbacks.
+"""
+import numpy as np
+import pytest
+
+from f1pred.ensemble import combine_pace, EnsembleConfig
+
+
+@pytest.fixture
+def cfg():
+    return EnsembleConfig()
+
+
+def _ordering(arr):
+    return np.argsort(np.asarray(arr)).tolist()
+
+
+def test_race_session_uses_race_weights(cfg):
+    """With race weights favouring Elo, the blended order follows Elo."""
+    cfg.w_gbm, cfg.w_elo, cfg.w_bt, cfg.w_mixed = 0.0, 1.0, 0.0, 0.0
+    cfg.w_gbm_quali, cfg.w_elo_quali, cfg.w_bt_quali, cfg.w_mixed_quali = 1.0, 0.0, 0.0, 0.0
+
+    gbm = np.array([1.0, 2.0, 3.0, 4.0])      # ascending
+    elo = np.array([4.0, 3.0, 2.0, 1.0])      # descending
+    flat = np.array([5.0, 5.0, 5.0, 5.0])     # constant -> z == 0
+
+    out = combine_pace(gbm, elo, flat, flat, cfg, session_type="race")
+    assert _ordering(out) == _ordering(elo)
+
+
+@pytest.mark.parametrize("session", ["qualifying", "sprint_qualifying"])
+def test_quali_sessions_use_quali_weights(cfg, session):
+    """Qualifying/sprint-qualifying select the *_quali weights (here: GBM)."""
+    cfg.w_gbm, cfg.w_elo, cfg.w_bt, cfg.w_mixed = 0.0, 1.0, 0.0, 0.0
+    cfg.w_gbm_quali, cfg.w_elo_quali, cfg.w_bt_quali, cfg.w_mixed_quali = 1.0, 0.0, 0.0, 0.0
+
+    gbm = np.array([1.0, 2.0, 3.0, 4.0])      # ascending
+    elo = np.array([4.0, 3.0, 2.0, 1.0])      # descending
+    flat = np.array([5.0, 5.0, 5.0, 5.0])
+
+    out = combine_pace(gbm, elo, flat, flat, cfg, session_type=session)
+    # Order follows GBM (quali weight), NOT Elo (race weight).
+    assert _ordering(out) == _ordering(gbm)
+    assert _ordering(out) != _ordering(elo)
+
+
+def test_constant_component_zero_variance_fallback(cfg):
+    """A component with ~zero variance contributes zeros, not NaN/inf.
+
+    combine_pace adds a deterministic tie-breaking jitter on the order of 1e-6,
+    so the output is zero up to that jitter rather than exactly zero.
+    """
+    cfg.w_gbm, cfg.w_elo, cfg.w_bt, cfg.w_mixed = 1.0, 0.0, 0.0, 0.0
+    const = np.array([7.0, 7.0, 7.0, 7.0])
+    out = combine_pace(const, const, const, const, cfg, session_type="race")
+    assert np.all(np.isfinite(out))
+    assert np.max(np.abs(out)) < 1e-3  # only the ~1e-6 jitter remains
+
+
+def test_nonpositive_weight_sum_falls_back_to_equal_weights(cfg):
+    """All-zero weights must not divide by zero; output stays finite."""
+    cfg.w_gbm = cfg.w_elo = cfg.w_bt = cfg.w_mixed = 0.0
+    gbm = np.array([1.0, 2.0, 3.0, 4.0])
+    elo = np.array([4.0, 3.0, 2.0, 1.0])
+    bt = np.array([1.0, 1.0, 2.0, 2.0])
+    mixed = np.array([2.0, 1.0, 2.0, 1.0])
+    out = combine_pace(gbm, elo, bt, mixed, cfg, session_type="race")
+    assert len(out) == 4
+    assert np.all(np.isfinite(out))
+
+
+def test_blended_output_is_zero_centred_for_znormed_inputs(cfg):
+    """The final blend is z-normalised, so it is mean-zero up to the tiny jitter."""
+    cfg.w_gbm = cfg.w_elo = cfg.w_bt = cfg.w_mixed = 0.25
+    rng = np.random.default_rng(0)
+    a, b, c, d = (rng.standard_normal(10) for _ in range(4))
+    out = combine_pace(a, b, c, d, cfg, session_type="race")
+    # Mean is ~0 plus the mean of the deterministic jitter (~(n-1)/2 * 1e-6).
+    assert abs(float(np.mean(out))) < 1e-3
+    assert float(np.std(out)) == pytest.approx(1.0, abs=1e-2)

--- a/tests/test_fastf1_backend.py
+++ b/tests/test_fastf1_backend.py
@@ -1,0 +1,295 @@
+"""Tests for f1pred.data.fastf1_backend.
+
+This module was previously ~20% covered with no dedicated test file. The
+position-derivation logic (patch_missing_positions), the datetime
+normalisation helper, the cache-init guard, and the weather/classification
+readers are all exercisable without a real FastF1 install by feeding
+synthetic DataFrames / fake session objects, which is what these tests do.
+"""
+import sys
+import types
+from datetime import datetime, timezone, timedelta
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from f1pred.data import fastf1_backend as fb
+
+
+# --------------------------------------------------------------------------
+# patch_missing_positions — pure ranking derivation
+# --------------------------------------------------------------------------
+
+class TestPatchMissingPositions:
+    def test_qualifying_ranks_by_qtimes_q3_first(self):
+        """Lower Q3 wins; missing Q3 falls back to later columns / last place."""
+        df = pd.DataFrame({
+            "Abbreviation": ["A", "B", "C"],
+            "Position": [np.nan, np.nan, np.nan],
+            "Q1": ["00:01:31", "00:01:30", "00:01:32"],
+            "Q2": ["00:01:30", "00:01:29", "00:01:40"],
+            "Q3": ["00:01:30", "00:01:29", ""],
+        })
+        out = fb.patch_missing_positions("Qualifying", df)
+        pos = dict(zip(out["Abbreviation"], out["Position"]))
+        assert pos == {"B": 1, "A": 2, "C": 3}
+
+    def test_race_ranks_by_total_time(self):
+        df = pd.DataFrame({
+            "Abbreviation": ["A", "B", "C"],
+            "Position": [np.nan, np.nan, np.nan],
+            "Time": ["00:00:10", "00:00:09", "00:00:11"],
+        })
+        out = fb.patch_missing_positions("Race", df)
+        pos = dict(zip(out["Abbreviation"], out["Position"]))
+        assert pos == {"B": 1, "A": 2, "C": 3}
+
+    def test_already_populated_returns_unchanged(self):
+        df = pd.DataFrame({
+            "Abbreviation": ["A", "B"],
+            "Position": [1, 2],
+            "Time": ["00:00:11", "00:00:09"],  # would re-rank if it tried
+        })
+        out = fb.patch_missing_positions("Race", df)
+        # Untouched: not even re-sorted, despite Time disagreeing with Position.
+        assert list(out["Position"]) == [1, 2]
+        assert out is df
+
+    def test_no_time_columns_leaves_positions_nan(self):
+        df = pd.DataFrame({
+            "Abbreviation": ["A", "B"],
+            "Position": [np.nan, np.nan],
+        })
+        out = fb.patch_missing_positions("Race", df)
+        assert out["Position"].isna().all()
+
+    def test_all_qtimes_missing_leaves_positions_nan(self):
+        df = pd.DataFrame({
+            "Abbreviation": ["A", "B"],
+            "Position": [np.nan, np.nan],
+            "Q1": ["", "NaT"],
+            "Q2": ["nan", ""],
+            "Q3": ["", ""],
+        })
+        out = fb.patch_missing_positions("Qualifying", df)
+        assert out["Position"].isna().all()
+
+    def test_accepts_native_timedelta_columns(self):
+        df = pd.DataFrame({
+            "Abbreviation": ["A", "B"],
+            "Position": [np.nan, np.nan],
+            "Time": pd.to_timedelta(["00:00:10", "00:00:09"]),
+        })
+        out = fb.patch_missing_positions("Race", df)
+        pos = dict(zip(out["Abbreviation"], out["Position"]))
+        assert pos == {"B": 1, "A": 2}
+
+
+# --------------------------------------------------------------------------
+# _to_py_datetime — timezone normalisation
+# --------------------------------------------------------------------------
+
+class TestToPyDatetime:
+    def test_naive_datetime_assumed_utc(self):
+        out = fb._to_py_datetime(datetime(2024, 5, 1, 12, 0, 0))
+        assert out.tzinfo == timezone.utc
+        assert out.hour == 12
+
+    def test_aware_datetime_converted_to_utc(self):
+        plus2 = timezone(timedelta(hours=2))
+        out = fb._to_py_datetime(datetime(2024, 5, 1, 12, 0, 0, tzinfo=plus2))
+        assert out.tzinfo == timezone.utc
+        assert out.hour == 10  # 12:00 +02:00 -> 10:00 UTC
+
+    def test_pandas_timestamp_via_to_pydatetime(self):
+        out = fb._to_py_datetime(pd.Timestamp("2024-05-01 12:00:00"))
+        assert isinstance(out, datetime)
+        assert out.tzinfo == timezone.utc
+
+    def test_non_datetime_returns_none(self):
+        assert fb._to_py_datetime("not-a-date") is None
+
+    def test_none_returns_none(self):
+        assert fb._to_py_datetime(None) is None
+
+
+# --------------------------------------------------------------------------
+# init_fastf1 — cache guard, never raises
+# --------------------------------------------------------------------------
+
+@pytest.fixture
+def reset_cache_flag():
+    original = fb._CACHE_INITED
+    fb._CACHE_INITED = False
+    yield
+    fb._CACHE_INITED = original
+
+
+def _fake_fastf1_module(enable_side_effect=None):
+    mod = types.ModuleType("fastf1")
+
+    class _Cache:
+        @staticmethod
+        def enable_cache(path):
+            if enable_side_effect:
+                enable_side_effect(path)
+
+    mod.Cache = _Cache
+    return mod
+
+
+class TestInitFastf1:
+    def test_returns_false_when_fastf1_missing(self, monkeypatch, reset_cache_flag):
+        # Setting the module to None makes `import fastf1` raise ImportError.
+        monkeypatch.setitem(sys.modules, "fastf1", None)
+        assert fb.init_fastf1("/tmp/cache") is False
+
+    def test_enables_cache_and_sets_flag(self, monkeypatch, reset_cache_flag):
+        calls = []
+        monkeypatch.setitem(
+            sys.modules, "fastf1",
+            _fake_fastf1_module(enable_side_effect=lambda p: calls.append(p)),
+        )
+        assert fb.init_fastf1("/tmp/cache") is True
+        assert calls == ["/tmp/cache"]
+        assert fb._CACHE_INITED is True
+
+    def test_idempotent_when_already_inited(self, monkeypatch, reset_cache_flag):
+        calls = []
+        monkeypatch.setitem(
+            sys.modules, "fastf1",
+            _fake_fastf1_module(enable_side_effect=lambda p: calls.append(p)),
+        )
+        fb._CACHE_INITED = True
+        assert fb.init_fastf1("/tmp/cache") is True
+        assert calls == []  # enable_cache not called the second time
+
+    def test_returns_false_on_cache_failure(self, monkeypatch, reset_cache_flag):
+        def boom(path):
+            raise RuntimeError("disk full")
+
+        monkeypatch.setitem(
+            sys.modules, "fastf1", _fake_fastf1_module(enable_side_effect=boom),
+        )
+        assert fb.init_fastf1("/tmp/cache") is False
+        assert fb._CACHE_INITED is False
+
+
+# --------------------------------------------------------------------------
+# get_event — swallows failures
+# --------------------------------------------------------------------------
+
+def test_get_event_returns_none_when_fastf1_unavailable(monkeypatch):
+    monkeypatch.setitem(sys.modules, "fastf1", None)
+    assert fb.get_event(2024, 1) is None
+
+
+# --------------------------------------------------------------------------
+# get_session_weather_status
+# --------------------------------------------------------------------------
+
+class _FakeSession:
+    def __init__(self, weather_data=None, laps=None, results=None, session_info=None, name="Race"):
+        self.weather_data = weather_data
+        self.laps = laps
+        self.results = results
+        self.session_info = session_info or {}
+        self.name = name
+
+
+class TestWeatherStatus:
+    def test_none_when_event_missing(self, monkeypatch):
+        monkeypatch.setattr(fb, "get_event", lambda s, r: None)
+        assert fb.get_session_weather_status(2024, 1, "Race") is None
+
+    def test_dry_when_no_rain_or_wet_compound(self, monkeypatch):
+        sess = _FakeSession(
+            weather_data=pd.DataFrame({"Rainfall": [False, False]}),
+            laps=pd.DataFrame({"Compound": ["SOFT", "MEDIUM"]}),
+        )
+        monkeypatch.setattr(fb, "get_event", lambda s, r: object())
+        monkeypatch.setattr(fb, "_load_session_with_timeout", lambda *a, **k: sess)
+        out = fb.get_session_weather_status(2024, 1, "Race")
+        assert out == {"is_wet": False, "rainfall": False, "track_status": "DRY"}
+
+    def test_wet_from_rainfall(self, monkeypatch):
+        sess = _FakeSession(
+            weather_data=pd.DataFrame({"Rainfall": [False, True]}),
+            laps=pd.DataFrame({"Compound": ["SOFT"]}),
+        )
+        monkeypatch.setattr(fb, "get_event", lambda s, r: object())
+        monkeypatch.setattr(fb, "_load_session_with_timeout", lambda *a, **k: sess)
+        out = fb.get_session_weather_status(2024, 1, "Race")
+        assert out["is_wet"] is True
+        assert out["rainfall"] is True
+        assert out["track_status"] == "WET"
+
+    def test_wet_from_intermediate_compound(self, monkeypatch):
+        sess = _FakeSession(
+            weather_data=pd.DataFrame({"Rainfall": [False]}),
+            laps=pd.DataFrame({"Compound": ["SOFT", "INTERMEDIATE"]}),
+        )
+        monkeypatch.setattr(fb, "get_event", lambda s, r: object())
+        monkeypatch.setattr(fb, "_load_session_with_timeout", lambda *a, **k: sess)
+        out = fb.get_session_weather_status(2024, 1, "Race")
+        assert out["is_wet"] is True
+        assert out["track_status"] == "WET"
+
+    def test_returns_none_on_load_failure(self, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("timeout")
+
+        monkeypatch.setattr(fb, "get_event", lambda s, r: object())
+        monkeypatch.setattr(fb, "_load_session_with_timeout", boom)
+        assert fb.get_session_weather_status(2024, 1, "Race") is None
+
+
+# --------------------------------------------------------------------------
+# get_session_classification
+# --------------------------------------------------------------------------
+
+class TestGetSessionClassification:
+    def test_none_when_event_missing(self, monkeypatch):
+        monkeypatch.setattr(fb, "get_event", lambda s, r: None)
+        assert fb.get_session_classification(2024, 1, "Race") is None
+
+    def test_returns_populated_results(self, monkeypatch):
+        results = pd.DataFrame({"Abbreviation": ["A", "B"], "Position": [1, 2]})
+        sess = _FakeSession(results=results, name="Race")
+        monkeypatch.setattr(fb, "get_event", lambda s, r: object())
+        monkeypatch.setattr(fb, "_load_session_with_timeout", lambda *a, **k: sess)
+        out = fb.get_session_classification(2024, 1, "Race")
+        assert list(out["Position"]) == [1, 2]
+
+    def test_none_on_load_failure(self, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(fb, "get_event", lambda s, r: object())
+        monkeypatch.setattr(fb, "_load_session_with_timeout", boom)
+        assert fb.get_session_classification(2024, 1, "Race") is None
+
+
+# --------------------------------------------------------------------------
+# get_session_times
+# --------------------------------------------------------------------------
+
+class TestGetSessionTimes:
+    def test_none_when_event_missing(self):
+        assert fb.get_session_times(None, "Race") is None
+
+    def test_reads_start_and_end_from_session_info(self, monkeypatch):
+        start = datetime(2024, 5, 1, 13, 0, tzinfo=timezone.utc)
+        end = datetime(2024, 5, 1, 15, 0, tzinfo=timezone.utc)
+        sess = _FakeSession(session_info={"StartDate": start, "EndDate": end})
+        monkeypatch.setattr(fb, "_load_session_with_timeout", lambda *a, **k: sess)
+        out = fb.get_session_times(object(), "Race")
+        assert out == (start, end)
+
+    def test_none_on_load_failure(self, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(fb, "_load_session_with_timeout", boom)
+        assert fb.get_session_times(object(), "Race") is None

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -165,16 +165,15 @@ class TestComputeEventMetricsExceptions:
         # Should return nan because len is 0 (< 2)
         assert np.isnan(brier_pairwise(probs, positions))
 
-    def test_dfv_empty_via_actual_positions(self):
-        # We need a dataframe where actual_position is not all NA (so it passes line 54)
-        # BUT after dropna on actual_position, it IS empty. Is that possible?
-        # Actually no, if actual_position has at least one non-NA value, dropna will leave at least one row.
-        # Wait, what if we have a dataframe with 0 rows to start with?
-        _ = pd.DataFrame(columns=["driver_id", "predicted_position", "actual_position"])
-        # df.shape[0] == 0. df["actual_position"].isna().all() is True, so it hits line 54.
-
-        # What if it's all NA but `isna().all()` evaluates to false?
-        pass
+    def test_empty_frame_yields_nan_metrics_with_zero_n(self):
+        # An empty frame has an all-NA actual_position column, so every metric
+        # is NaN and the reported sample count is zero.
+        df = pd.DataFrame(columns=["driver_id", "predicted_position", "actual_position"])
+        metrics = compute_event_metrics(df, None, None, "race", 2023, 1)
+        assert metrics["n"] == 0
+        assert np.isnan(metrics["spearman"])
+        assert np.isnan(metrics["kendall"])
+        assert np.isnan(metrics["brier_pairwise"])
 
     def test_compute_event_empty_dfv(self):
         # Line 64 is reached if dfv.empty is true AFTER dropna.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -157,9 +157,13 @@ def test_models_qual_team_avg_nan_handling():
 
     X_current = pd.DataFrame({"driverId": ["d1", "d2", "d3"], "form_index": [0.0, 1.0, 2.0]})
 
-    # Should not crash on np.bincount
+    # NaN round/constructorId must not cause a negative-index crash in
+    # np.bincount when computing qualifying team averages.
     res = build_hist_training_X(hist, X_current, ref_date)
 
-    # We might not get enough history to build an X matrix so it returns None,
-    # but the point is we didn't raise a ValueError due to bincount negative index.
-    pass
+    # With little history the builder may return None, but it must never raise
+    # and, when it does return a matrix, it must be well-formed.
+    assert res is None or isinstance(res, pd.DataFrame)
+    if isinstance(res, pd.DataFrame):
+        assert "driverId" in res.columns
+        assert len(res) > 0

--- a/tests/test_prediction_manager.py
+++ b/tests/test_prediction_manager.py
@@ -562,6 +562,12 @@ class TestPredictionManagerPredictRoundSessions:
 
             manager._predict_round(jc, 2024, 1, {"raceName": "Normal GP", "round": 1})
 
+            # The unmatched session type yields an empty session list, which must
+            # fall back to the default ["qualifying", "race"] (prediction_manager
+            # line ~554) rather than predicting nothing.
+            mock_predict.assert_called_once()
+            assert mock_predict.call_args.kwargs["sessions"] == ["qualifying", "race"]
+
 
 class TestPredictionManagerDiscord:
     def test_discord_webhook_url_validation(self, caplog):

--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -43,9 +43,12 @@ def test_build_session_features_filtering():
         {"round": "1", "raceName": "Good", "Circuit": {"Location": {"lat": "0", "long": "0"}}}
     ]
 
-    # This should find the "Good" race and not crash on the "Bad" one
+    # This should skip the malformed round=None row, resolve round 1, and not crash.
     X, meta, roster = build_session_features(mock_jc, mock_om, 2026, 1, "race", datetime.now(timezone.utc), cfg)
-    assert meta["raceName"] == "Good" if "raceName" in meta else True # Check it didn't fail
+    assert isinstance(meta, dict)
+    # The target round was resolved despite the malformed leading row.
+    assert meta["round"] == 1
+    assert meta["season"] == 2026
 
 def test_roster_derivation_filtering():
     """Test that _latest_completed_round_in_season ignores None rounds."""

--- a/tests/test_security_exceptions.py
+++ b/tests/test_security_exceptions.py
@@ -1,31 +1,11 @@
 
 from unittest.mock import patch, MagicMock
-from f1pred.util import sanitize_for_console
 import f1pred.predict
 
-def test_sanitize_exception_message():
-    """Verify that sanitize_for_console effectively neutralizes malicious exception messages."""
-
-    # 1. Newlines and Carriage Returns (Log Forging / Terminal Spoofing)
-    malicious_msg = "Error occurred\r\n[INFO] Forged Log Entry"
-    clean = sanitize_for_console(malicious_msg)
-    assert "\r" not in clean
-    assert "\n" not in clean
-    assert "Forged Log Entry" in clean
-    # Expect spaces instead (2 spaces for \r and \n)
-    assert "Error occurred  [INFO] Forged Log Entry" == clean
-
-    # 2. ANSI Codes (Terminal Injection)
-    ansi_msg = "\033[31mCritical Error\033[0m"
-    clean_ansi = sanitize_for_console(ansi_msg)
-    assert "\033" not in clean_ansi
-    assert "Critical Error" == clean_ansi
-
-    # 3. Mixed
-    mixed = "Error\n\033[31mHacked\033[0m"
-    clean_mixed = sanitize_for_console(mixed)
-    # \n -> space, ANSI removed. Result: "Error Hacked"
-    assert clean_mixed == "Error Hacked"
+# Direct sanitize_for_console behaviour (ANSI/newline/control-char handling) is
+# covered comprehensively by tests/test_security_sanitization.py. This file
+# keeps the integration test below, which proves run_predictions_for_event
+# sanitises exception messages *before* they reach the logger.
 
 @patch("f1pred.predict.logger")
 def test_predict_logs_sanitized_exception(mock_logger):

--- a/tests/test_security_sanitization.py
+++ b/tests/test_security_sanitization.py
@@ -22,6 +22,11 @@ def test_sanitize_removes_other_controls():
     # Null
     assert sanitize_for_console("Null\0Value") == "NullValue"
 
+def test_sanitize_preserves_non_ansi_brackets():
+    """Bracketed text that merely resembles an escape sequence is left intact."""
+    assert sanitize_for_console("Price: $100 [USD]") == "Price: $100 [USD]"
+    assert sanitize_for_console("array[0] = value") == "array[0] = value"
+
 def test_sanitize_preserves_unicode():
     """Verify unicode characters (like accents) are preserved."""
     assert sanitize_for_console("Pérez") == "Pérez"

--- a/tests/test_security_vuln.py
+++ b/tests/test_security_vuln.py
@@ -1,27 +1,13 @@
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
+from email.utils import format_datetime
 from unittest.mock import patch
-from f1pred.util import sanitize_for_console, StatusSpinner
+from f1pred.util import StatusSpinner
 from f1pred.data.jolpica import JolpicaClient
 from f1pred.data.open_meteo import OpenMeteoClient
 
-def test_sanitize_for_console_removes_ansi_codes():
-    # Input with ANSI codes (red text)
-    malicious_input = "\033[31mMalicious\033[0m"
-    sanitized = sanitize_for_console(malicious_input)
-    assert sanitized == "Malicious"
-
-    # Input with simple text
-    assert sanitize_for_console("Normal") == "Normal"
-
-    # Mixed content
-    mixed = "Hello \033[1mBold\033[0m World"
-    assert sanitize_for_console(mixed) == "Hello Bold World"
-
-    # Text that looks like ANSI but isn't quite (should pass through or be handled)
-    # The regex \x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]) covers standard escape sequences.
-    # We want to ensure it doesn't delete random text.
-    safe_ish = "Price: $100 [USD]"
-    assert sanitize_for_console(safe_ish) == safe_ish
+# Note: direct sanitize_for_console behaviour is covered comprehensively by
+# tests/test_security_sanitization.py. This file keeps only the integration-style
+# checks (StatusSpinner) that exercise sanitisation through a real call path.
 
 def test_status_spinner_sanitizes_message(capsys):
     # Verify StatusSpinner automatically sanitizes its input message
@@ -41,29 +27,23 @@ def test_jolpica_retry_after_dos_prevention():
     to prevent a Denial of Service (DoS) where a malicious or broken API
     forces the application to sleep for an excessive amount of time.
     """
-    # 1. Test with a reasonable Retry-After value (should be respected)
-    headers_ok = {"Retry-After": "120"}
-    JolpicaClient._retry_after_seconds(headers_ok, attempt=0, base=1.0, cap=30.0)
-    # Currently, it respects it fully. After fix, it should still be 120 (if we cap at say 300)
-    # or if we cap at 30, it will be 30.
-    # The current code returns 120.
+    MAX_ALLOWED_SLEEP = 300.0  # the hard cap implemented in _retry_after_seconds
 
-    # 2. Test with a MALICIOUS Retry-After value (e.g. 10 years)
-    headers_bad = {"Retry-After": "315360000"}
-    val_bad = JolpicaClient._retry_after_seconds(headers_bad, attempt=0, base=1.0, cap=30.0)
+    # 1. A reasonable numeric Retry-After (under the cap) is respected exactly.
+    val_ok = JolpicaClient._retry_after_seconds(
+        {"Retry-After": "120"}, attempt=0, base=1.0, cap=30.0)
+    assert val_ok == 120.0
 
-    # Assert behavior.
-    # BEFORE FIX: val_bad would be 315360000.0
-    # AFTER FIX: val_bad should be capped (e.g. 300.0)
+    # 2. A malicious numeric Retry-After (10 years) is capped, not honoured.
+    val_bad = JolpicaClient._retry_after_seconds(
+        {"Retry-After": "315360000"}, attempt=0, base=1.0, cap=30.0)
+    assert val_bad == MAX_ALLOWED_SLEEP
 
-    # We assert that we are implementing a cap.
-    # Let's say we decide the cap is 300 seconds (5 minutes).
-    MAX_ALLOWED_SLEEP = 300.0
-
-    # This assertion is expected to FAIL before the fix if the code just returns `secs`.
-    # But since I can't verify failure in this environment easily (I just want to implement the fix),
-    # I will assert the SAFE behavior I want to see.
-    assert val_bad <= MAX_ALLOWED_SLEEP, f"Retry-After value {val_bad} exceeded safety cap of {MAX_ALLOWED_SLEEP}"
+    # 3. An HTTP-date far in the future is also capped (covers the date branch).
+    future = format_datetime(datetime.now(timezone.utc) + timedelta(days=365))
+    val_date = JolpicaClient._retry_after_seconds(
+        {"Retry-After": future}, attempt=0, base=1.0, cap=30.0)
+    assert val_date <= MAX_ALLOWED_SLEEP
 
 def test_open_meteo_timezone_validation():
     """Test that OpenMeteoClient validates timezone input preventing potential injection or errors."""

--- a/tests/test_util_core.py
+++ b/tests/test_util_core.py
@@ -45,16 +45,19 @@ def test_session_with_retries():
 
 def test_init_caches_disabled():
     # Arrange
+    import requests_cache
     from f1pred.util import init_caches
     class MockConfig:
         pass
-    cfg = MockConfig()
+    cfg = MockConfig()  # deliberately missing all cache config attributes
 
-    # Act
-    # Calling init_caches with disable_cache=True should return immediately.
-    # We verify it doesn't raise any errors or try to access missing config attributes.
-    init_caches(cfg, disable_cache=True)
+    before = requests_cache.is_installed()
 
-    # Assert
-    # If no exception is raised, the test passes and coverage is achieved for lines 133-134.
-    assert True
+    # Act: disable_cache=True must short-circuit before any config access.
+    result = init_caches(cfg, disable_cache=True)
+
+    # Assert: it returned without touching cfg (a MockConfig with no attributes
+    # would raise AttributeError if the body ran) and did not install/uninstall
+    # a global cache.
+    assert result is None
+    assert requests_cache.is_installed() == before

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -1,18 +1,37 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from f1pred.web import app, init_web
+# NOTE: reference the live module (f1pred.web) at runtime rather than binding
+# `app`/`init_web` at import time. Another test module (test_config_security)
+# calls importlib.reload(f1pred.web), which rebinds the module's `app` and its
+# `_login_attempts` counter. Referencing the live module guarantees the
+# TestClient's app and the counter we clear come from the *same* module object,
+# keeping the rate-limit test deterministic regardless of suite ordering.
+import f1pred.web as fweb
 from f1pred.config import load_config
+
+
+@pytest.fixture(autouse=True)
+def reset_login_attempts():
+    """Clear the module-global login-attempt counter before/after each test.
+
+    Without this, _login_attempts persists across tests in the same process,
+    making the rate-limit test order-dependent.
+    """
+    fweb._login_attempts.clear()
+    yield
+    fweb._login_attempts.clear()
+
 
 @pytest.fixture
 def client():
     # Use real config for simple init
     cfg = load_config("config.yaml")
-    init_web(cfg)
-    yield TestClient(app)
-    import f1pred.web as web_module
-    if web_module._prediction_manager:
-        web_module._prediction_manager.stop()
+    fweb.init_web(cfg)
+    yield TestClient(fweb.app)
+    if fweb._prediction_manager:
+        fweb._prediction_manager.stop()
+
 
 def test_get_predict_too_many_sessions(client):
     # Pass 11 session parameters
@@ -22,6 +41,7 @@ def test_get_predict_too_many_sessions(client):
     assert response.status_code == 400
     assert response.json() == {"detail": "Too many sessions requested"}
 
+
 def test_get_predict_stream_too_many_sessions(client):
     # Pass 11 session parameters
     sessions = ["race"] * 11
@@ -30,10 +50,9 @@ def test_get_predict_stream_too_many_sessions(client):
     assert response.status_code == 400
     assert response.json() == {"detail": "Too many sessions requested"}
 
+
 @pytest.fixture
 def client_with_auth(client):
-    import f1pred.web as web_module
-
     # Login to get token
     response = client.post("/api/auth/token", data={"username": "admin", "password": "admin"})
     token = response.json()["access_token"]
@@ -41,30 +60,37 @@ def client_with_auth(client):
     client.headers.update({"Authorization": f"Bearer {token}"})
 
     yield client
-    if web_module._prediction_manager:
-        web_module._prediction_manager.stop()
+    if fweb._prediction_manager:
+        fweb._prediction_manager.stop()
+
 
 def test_webhook_ssrf_protection_invalid_scheme(client_with_auth):
     response = client_with_auth.post("/api/settings/test-webhook", json={"url": "file:///etc/passwd"})
     assert response.status_code == 400
 
+
 def test_webhook_ssrf_protection_non_discord(client_with_auth):
     response = client_with_auth.post("/api/settings/test-webhook", json={"url": "https://example.com"})
     assert response.status_code == 400
+
 
 def test_webhook_ssrf_protection_startswith_bypass(client_with_auth):
     response = client_with_auth.post("/api/settings/test-webhook", json={"url": "https://discord.com@127.0.0.1:80/api/webhooks/"})
     assert response.status_code == 400
 
+
 def test_login_rate_limiting(client):
-    # Send 10 failed login attempts
+    # Reset immediately before exercising the limit so the test is independent
+    # of any login attempts made by earlier tests/fixtures.
+    fweb._login_attempts.clear()
+
+    # With a freshly-cleared counter, the first 10 failed attempts are rejected
+    # with 401 (bad credentials), not throttled.
     for _ in range(10):
         response = client.post("/api/auth/token", data={"username": "admin", "password": "wrongpassword"})
-        if response.status_code == 429:
-            break # Stop if rate limit already hit from other tests
         assert response.status_code == 401
 
-    # The next attempt should be rate limited
+    # The 11th attempt within the window is rate limited.
     response = client.post("/api/auth/token", data={"username": "admin", "password": "wrongpassword"})
     assert response.status_code == 429
     assert "Too many login attempts" in response.json()["detail"]


### PR DESCRIPTION
## Summary

A full audit of the 56-file test suite, followed by acting on the findings across three fronts: **fixing a real bug the tests should have caught**, **adding the highest-value missing coverage**, and **removing/strengthening superficial and flaky tests**.

Overall coverage **67.18% → 74.47%** (floor raised 66.5% → 73.0%). Suite is green: **486 passed, 2 skipped**.

## 🔴 Real bug found & fixed

`CalibrationManager.run_calibration` wrote `objective_score = float(res.fun)` but the variable in scope is `best_res` — `res` is never defined. Every *successful* calibration therefore raised `NameError`, which the broad `except Exception` swallowed, so calibration silently failed and `objective_score` was never stored. No test ever invoked `run_calibration` (calibrate.py sat at ~22% coverage), so this went undetected.

- Fixed `res.fun` → `best_res.fun`.
- Added `tests/test_calibration_run.py` that drives `run_calibration` end-to-end over a small synthetic dataset (mocking only feature/GBM building, capping the optimiser iterations) so it actually reaches the weight-write path. Verified the regression test fails with `NameError` on the old code and passes on the fix.

## New coverage for previously-untested modules

| Module | Before | After | New file |
|--------|-------:|------:|----------|
| `data/fastf1_backend.py` | 20% | 74% | `tests/test_fastf1_backend.py` — `patch_missing_positions` ranking derivation (quali Q-times / race Time / already-populated / no-time-cols), `_to_py_datetime` tz normalisation, `init_fastf1` cache guard & ImportError path, `get_session_weather_status`, `get_session_classification`, `get_session_times` |
| `auth.py` | 89% | 98% | `tests/test_auth.py` — password verify/reject, 72-byte bcrypt truncation, JWT round-trip/expiry, and the `get_current_user` 401 branches (invalid token, expired, missing `sub`, unknown user, wrong signing key) |
| `calibrate.py` | 22% | 83% | `tests/test_calibration_run.py` (above) |
| `ensemble.py` | 85% | 92% | `tests/test_ensemble_quali.py` — the `combine_pace` qualifying-weight branch (the reason the `*_quali` weight set exists), zero-variance & non-positive-weight fallbacks, final z-normalisation |

## Superficial / flaky tests fixed

- **No-op assertions replaced with real ones:**
  - `test_metrics.py` — `test_dfv_empty_via_actual_positions` was a comment essay ending in `pass`; now actually calls `compute_event_metrics` and asserts NaN metrics + `n == 0`.
  - `test_util_core.py::test_init_caches_disabled` — was `assert True`; now asserts the disabled path returns `None` and does not change global cache install state.
  - `test_models.py::test_models_qual_team_avg_nan_handling` — ended in `pass`; now asserts the returned frame is well-formed.
  - `test_robustness.py::test_build_session_features_filtering` — assertion `== "Good" if "raceName" in meta else True` was *always* the no-op `else True` branch (meta never contains `raceName`); now asserts the malformed `round: None` row is skipped and round 1 resolves.
  - `test_prediction_manager.py::test_predict_round_fallback_sessions` — had no assertions; now asserts the unmatched session type falls back to `["qualifying", "race"]`.
- **Flaky fixture seeded:** `conftest.py::sample_features` used unseeded `np.random.randn`, making ordering/variance tests in `test_models.py` occasionally flaky — now uses a seeded RNG.
- **Order-dependent test made deterministic:** `test_web_security.py::test_login_rate_limiting` relied on cross-test global `_login_attempts` state (it had a defensive `break` admitting this). Added an autouse reset that references the live module (surviving `importlib.reload(f1pred.web)` from `test_config_security`) plus an explicit in-body clear.

## Redundancy pruned / strengthened

- `sanitize_for_console` was tested in 5 places. Removed the two pure-duplicate direct-call tests (`test_security_vuln.py::test_sanitize_for_console_removes_ansi_codes`, `test_security_exceptions.py::test_sanitize_exception_message`); kept the comprehensive `test_security_sanitization.py` (added the one unique "non-ANSI brackets preserved" case it was missing) and the genuinely-distinct integration tests (formatter, `print_session_console`, predict-logging).
- `test_security_vuln.py::test_jolpica_retry_after_dos_prevention` — the "reasonable value" case asserted nothing; now asserts the numeric value is honoured exactly, the malicious value is capped at the real `MAX_RETRY_AFTER` (300s), and adds an HTTP-date branch case.

## Notes / not done (documented for follow-up)

The audit also flagged lower-priority items left for a follow-up to keep this PR reviewable: parametrising the 3× `build_hist_training_X` boost clones (season/quali/sprint) and the 3× jolpica `get_season_*_results` merge clones, collapsing the over-parametrised `TestRosterSizeIsUnconstrained`, and either running the CI-skipped Playwright tests (`test_ui_fix.py`, `test_ui_layout.py`) in a real browser stage or moving them out of pytest (they never execute in CI today). The largest remaining coverage gap is `features.py` (44%) — most feature-engineering functions still lack direct correctness tests.

https://claude.ai/code/session_016DrpGRTkkeHzGooeNkKT7v

---
_Generated by [Claude Code](https://claude.ai/code/session_016DrpGRTkkeHzGooeNkKT7v)_