### PR TITLE
Test suite follow-ups: features.py correctness coverage, dedupe clones, split browser e2e

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,29 @@
+# Browser end-to-end tests
+
+These Playwright tests drive `f1pred/templates/index.html` in a real Chromium
+instance to verify client-side (Alpine.js) behaviour that cannot be checked from
+Python:
+
+- `test_ui_fix.py` — background live-update round gating: an out-of-band
+  prediction for a non-active round must be cached, not rendered, while an
+  update matching the active round is rendered.
+- `test_ui_layout.py` — responsive `getFactorLimit()` offsets across desktop /
+  medium / mobile viewport widths.
+
+## Why they live here and not in `tests/`
+
+They require a browser, so they are **not** part of the default unit-test run
+(`make test`, which only collects `tests/`). Keeping them under `e2e/` means the
+default suite never silently skips them — they are an opt-in suite you run
+explicitly when changing the UI.
+
+## Running them
+
+```bash
+pip install pytest-playwright
+playwright install chromium
+pytest e2e/
+```
+
+If `pytest-playwright` is not installed the tests skip with a clear reason
+rather than erroring.

--- a/e2e/test_ui_fix.py
+++ b/e2e/test_ui_fix.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     HAS_PLAYWRIGHT = False
 
-@pytest.mark.skipif(not HAS_PLAYWRIGHT or os.environ.get("CI") == "true", reason="Skipping Playwright tests in CI environment or if playwright is missing")
+@pytest.mark.skipif(not HAS_PLAYWRIGHT, reason="Playwright not installed (see e2e/README.md)")
 def test_ui_logic_v6_sync(page: "Page"):
     """Verify UI logic v6: Background sync doesn't overwrite wrong round."""
     abs_path = os.path.abspath("f1pred/templates/index.html")

--- a/e2e/test_ui_layout.py
+++ b/e2e/test_ui_layout.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     HAS_PLAYWRIGHT = False
 
-@pytest.mark.skipif(not HAS_PLAYWRIGHT or os.environ.get("CI") == "true", reason="Skipping Playwright tests in CI environment or if playwright is missing")
+@pytest.mark.skipif(not HAS_PLAYWRIGHT, reason="Playwright not installed (see e2e/README.md)")
 def test_factor_limit_offsets(page: "Page"):
     """Verify factor limit offsets in the UI."""
     abs_path = os.path.abspath("f1pred/templates/index.html")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,6 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 73.00
+fail_under = 76.00
 show_missing = true
 precision = 2

--- a/tests/test_feature_computations.py
+++ b/tests/test_feature_computations.py
@@ -1,0 +1,352 @@
+"""Direct correctness tests for the feature-engineering functions in features.py.
+
+The audit flagged features.py as the largest remaining coverage gap (~44%): most
+of the per-driver index builders (form, sprint, qualifying, circuit proficiency,
+grid/finish delta) and the raw Jolpica block parser had no direct correctness
+tests — they were only exercised transitively (if at all) through the heavily
+mocked build_session_features path, which never asserted on their numeric output.
+
+These tests pin the actual maths. For a single historical event the
+recency-weight cancels out of every weighted mean, so each index reduces to a
+closed form we can assert exactly:
+
+    form_index                 = -position
+    sprint_form_index          = -position + points
+    qualifying_form_index      = -qpos
+    grid_finish_delta          =  grid - position
+"""
+import numpy as np
+import pandas as pd
+import pytest
+from datetime import datetime, timezone, timedelta
+
+from f1pred.features import (
+    compute_form_indices,
+    compute_sprint_form,
+    compute_qualifying_form,
+    compute_sprint_qualifying_form,
+    compute_circuit_proficiency,
+    compute_circuit_globals,
+    compute_grid_finish_delta,
+    _parse_races_block,
+)
+
+REF = datetime(2024, 1, 1, tzinfo=timezone.utc)
+EVT = datetime(2023, 12, 1, tzinfo=timezone.utc)
+
+
+def _index(df, driver, col):
+    return float(df.loc[df["driverId"] == driver, col].iloc[0])
+
+
+# ---------------------------------------------------------------------------
+# compute_form_indices
+# ---------------------------------------------------------------------------
+
+def test_form_index_single_event_is_negative_position():
+    """With one event the recency weight cancels: form_index == -position."""
+    hist = pd.DataFrame({
+        "session": ["race", "race"], "season": [2023, 2023], "round": [1, 1],
+        "driverId": ["a", "b"], "position": [1.0, 2.0],
+        "points": [25.0, 18.0], "date": [EVT, EVT],
+    })
+    out = compute_form_indices(hist, REF, half_life_days=365)
+    assert _index(out, "a", "form_index") == pytest.approx(-1.0)
+    assert _index(out, "b", "form_index") == pytest.approx(-2.0)
+    # Better finisher must rank higher (closer to zero).
+    assert _index(out, "a", "form_index") > _index(out, "b", "form_index")
+
+
+def test_form_index_includes_sprint_sessions():
+    """Sprint finishes feed the overall form index alongside races."""
+    hist = pd.DataFrame({
+        "session": ["sprint"], "season": [2023], "round": [1],
+        "driverId": ["a"], "position": [3.0], "points": [6.0], "date": [EVT],
+    })
+    out = compute_form_indices(hist, REF, half_life_days=365)
+    # pos_score only (sprint contributes -position to the overall index)
+    assert _index(out, "a", "form_index") == pytest.approx(-3.0)
+
+
+def test_form_index_empty_returns_named_columns():
+    out = compute_form_indices(pd.DataFrame(), REF, half_life_days=365)
+    assert list(out.columns) == ["driverId", "form_index"]
+    assert out.empty
+
+
+def test_form_index_boost_factor_reweights_current_season():
+    """boost_factor > 1 pulls the index toward the current-season race result."""
+    old = datetime(2022, 6, 1, tzinfo=timezone.utc)
+    hist = pd.DataFrame({
+        "session": ["race", "race"], "season": [2022, 2023], "round": [1, 1],
+        "driverId": ["a", "a"], "position": [10.0, 2.0],
+        "points": [1.0, 18.0], "date": [old, EVT],
+    })
+    base = compute_form_indices(hist, REF, half_life_days=365, current_season=2023, boost_factor=1.0)
+    boosted = compute_form_indices(hist, REF, half_life_days=365, current_season=2023, boost_factor=5.0)
+    # Current-season result is P2 (-2); boosting must move the blend toward it.
+    assert _index(boosted, "a", "form_index") > _index(base, "a", "form_index")
+
+
+# ---------------------------------------------------------------------------
+# compute_sprint_form / compute_sprint_qualifying_form
+# ---------------------------------------------------------------------------
+
+def test_sprint_form_combines_position_and_points():
+    hist = pd.DataFrame({
+        "session": ["sprint", "sprint"], "season": [2023, 2023], "round": [1, 1],
+        "driverId": ["a", "b"], "position": [1.0, 2.0],
+        "points": [8.0, 7.0], "date": [EVT, EVT],
+    })
+    out = compute_sprint_form(hist, REF, half_life_days=365)
+    # weighted_val = -position + points
+    assert _index(out, "a", "sprint_form_index") == pytest.approx(7.0)
+    assert _index(out, "b", "sprint_form_index") == pytest.approx(5.0)
+
+
+def test_sprint_form_empty_when_no_sprint_sessions():
+    hist = pd.DataFrame({
+        "session": ["race"], "season": [2023], "round": [1],
+        "driverId": ["a"], "position": [1.0], "points": [25.0], "date": [EVT],
+    })
+    out = compute_sprint_form(hist, REF, half_life_days=365)
+    assert out.empty
+    assert list(out.columns) == ["driverId", "sprint_form_index"]
+
+
+def test_sprint_qualifying_form_is_negative_qpos():
+    hist = pd.DataFrame({
+        "session": ["sprint_qualifying", "sprint_qualifying"],
+        "season": [2023, 2023], "round": [1, 1],
+        "driverId": ["a", "b"], "qpos": [1.0, 6.0], "date": [EVT, EVT],
+    })
+    out = compute_sprint_qualifying_form(hist, REF, half_life_days=365)
+    assert _index(out, "a", "sprint_qualifying_form_index") == pytest.approx(-1.0)
+    assert _index(out, "b", "sprint_qualifying_form_index") == pytest.approx(-6.0)
+
+
+def test_sprint_qualifying_form_ignores_plain_qualifying():
+    hist = pd.DataFrame({
+        "session": ["qualifying"], "season": [2023], "round": [1],
+        "driverId": ["a"], "qpos": [1.0], "date": [EVT],
+    })
+    out = compute_sprint_qualifying_form(hist, REF, half_life_days=365)
+    assert out.empty
+
+
+# ---------------------------------------------------------------------------
+# compute_qualifying_form
+# ---------------------------------------------------------------------------
+
+def test_qualifying_form_is_negative_qpos_and_spans_both_quali_types():
+    hist = pd.DataFrame({
+        "session": ["qualifying", "sprint_qualifying"], "season": [2023, 2023],
+        "round": [1, 2], "driverId": ["a", "b"], "qpos": [1.0, 5.0],
+        "date": [EVT, EVT],
+    })
+    out = compute_qualifying_form(hist, REF, half_life_days=365)
+    assert _index(out, "a", "qualifying_form_index") == pytest.approx(-1.0)
+    assert _index(out, "b", "qualifying_form_index") == pytest.approx(-5.0)
+
+
+def test_qualifying_form_missing_qpos_column_returns_empty():
+    hist = pd.DataFrame({
+        "session": ["qualifying"], "season": [2023], "round": [1],
+        "driverId": ["a"], "date": [EVT],
+    })
+    out = compute_qualifying_form(hist, REF, half_life_days=365)
+    assert out.empty
+    assert list(out.columns) == ["driverId", "qualifying_form_index"]
+
+
+# ---------------------------------------------------------------------------
+# compute_circuit_proficiency
+# ---------------------------------------------------------------------------
+
+def test_circuit_proficiency_experience_avg_pos_and_dnf_rate():
+    """Three starts at one circuit: 2 finishes (P2, P4) and 1 DNF (accident)."""
+    hist = pd.DataFrame({
+        "session": ["race", "race", "race"],
+        "season": [2022, 2023, 2023], "round": [1, 1, 2],
+        "driverId": ["a", "a", "a"],
+        "position": [2.0, 4.0, np.nan],
+        "status": ["Finished", "Finished", "Accident"],
+        "circuitId": ["monza", "monza", "monza"],
+        "date": [datetime(2022, 1, 1, tzinfo=timezone.utc), EVT, EVT],
+    })
+    out = compute_circuit_proficiency(hist, "monza", REF)
+    row = out[out["driverId"] == "a"].iloc[0]
+    assert int(row["circuit_experience"]) == 3
+    assert row["circuit_avg_pos"] == pytest.approx(3.0)      # (2 + 4) / 2 finishes
+    assert row["circuit_dnf_rate"] == pytest.approx(1 / 3)   # 1 DNF of 3 starts
+
+
+def test_circuit_proficiency_filters_to_target_circuit_before_ref_date():
+    hist = pd.DataFrame({
+        "session": ["race", "race", "race"],
+        "season": [2023, 2023, 2099], "round": [1, 2, 1],
+        "driverId": ["a", "a", "a"],
+        "position": [1.0, 5.0, 1.0],
+        "status": ["Finished", "Finished", "Finished"],
+        "circuitId": ["monza", "spa", "monza"],
+        "date": [EVT, EVT, datetime(2099, 1, 1, tzinfo=timezone.utc)],
+    })
+    out = compute_circuit_proficiency(hist, "monza", REF)
+    # Only the single pre-ref-date Monza race counts (the 2099 one is filtered).
+    row = out[out["driverId"] == "a"].iloc[0]
+    assert int(row["circuit_experience"]) == 1
+    assert row["circuit_avg_pos"] == pytest.approx(1.0)
+
+
+def test_circuit_proficiency_missing_circuit_column_returns_empty():
+    hist = pd.DataFrame({
+        "session": ["race"], "season": [2023], "round": [1],
+        "driverId": ["a"], "position": [1.0], "status": ["Finished"], "date": [EVT],
+    })
+    out = compute_circuit_proficiency(hist, "monza", REF)
+    assert out.empty
+
+
+def test_circuit_proficiency_blank_circuit_id_returns_empty():
+    hist = pd.DataFrame({
+        "session": ["race"], "season": [2023], "round": [1], "driverId": ["a"],
+        "position": [1.0], "status": ["Finished"], "circuitId": ["monza"], "date": [EVT],
+    })
+    assert compute_circuit_proficiency(hist, "", REF).empty
+
+
+# ---------------------------------------------------------------------------
+# compute_circuit_globals
+# ---------------------------------------------------------------------------
+
+def test_circuit_globals_overtake_difficulty_and_dnf_rate():
+    hist = pd.DataFrame({
+        "session": ["race", "race", "race"],
+        "season": [2023, 2023, 2023], "round": [1, 2, 3],
+        "driverId": ["a", "b", "c"],
+        "grid": [5.0, 6.0, np.nan],
+        "position": [2.0, 4.0, np.nan],
+        "status": ["Finished", "Finished", "Accident"],
+        "circuitId": ["monza", "monza", "monza"],
+        "date": [EVT, EVT, EVT],
+    })
+    g = compute_circuit_globals(hist, "monza", REF)
+    # gains = (5-2)=3 and (6-4)=2 -> mean 2.5
+    assert g["circuit_overtake_difficulty"] == pytest.approx(2.5)
+    # 1 DNF of 3 classified rows
+    assert g["global_circuit_dnf_rate"] == pytest.approx(1 / 3)
+
+
+def test_circuit_globals_no_history_returns_neutral_defaults():
+    g = compute_circuit_globals(pd.DataFrame(), "monza", REF)
+    assert g == {"circuit_overtake_difficulty": 0.0, "global_circuit_dnf_rate": 0.08}
+
+
+# ---------------------------------------------------------------------------
+# compute_grid_finish_delta
+# ---------------------------------------------------------------------------
+
+def test_grid_finish_delta_is_grid_minus_position():
+    hist = pd.DataFrame({
+        "session": ["race", "race"], "season": [2023, 2023], "round": [1, 1],
+        "driverId": ["a", "b"], "grid": [3.0, 1.0], "position": [1.0, 2.0],
+        "date": [EVT, EVT],
+    })
+    out = compute_grid_finish_delta(hist, REF, half_life_days=365)
+    assert _index(out, "a", "grid_finish_delta") == pytest.approx(2.0)   # gained 2
+    assert _index(out, "b", "grid_finish_delta") == pytest.approx(-1.0)  # lost 1
+
+
+def test_grid_finish_delta_ignores_non_race_sessions():
+    hist = pd.DataFrame({
+        "session": ["qualifying"], "season": [2023], "round": [1],
+        "driverId": ["a"], "grid": [3.0], "position": [1.0], "date": [EVT],
+    })
+    out = compute_grid_finish_delta(hist, REF, half_life_days=365)
+    assert out.empty
+    assert list(out.columns) == ["driverId", "grid_finish_delta"]
+
+
+# ---------------------------------------------------------------------------
+# _parse_races_block
+# ---------------------------------------------------------------------------
+
+def _race_block():
+    return [{
+        "season": "2023", "round": "1", "date": "2023-03-05", "time": "14:00:00Z",
+        "Circuit": {"circuitName": "Bahrain", "circuitId": "bahrain",
+                    "Location": {"lat": "26.0", "long": "50.5"}},
+        "Results": [{
+            "Driver": {"driverId": "verstappen", "code": "VER"},
+            "Constructor": {"constructorId": "red_bull"},
+            "grid": "1", "position": "1", "status": "Finished", "points": "25",
+            "FastestLap": {"rank": "1"},
+        }],
+    }]
+
+
+def test_parse_races_block_race_row_normalisation():
+    rows = _parse_races_block(_race_block(), "race", REF)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["session"] == "race"
+    assert row["season"] == 2023 and row["round"] == 1
+    assert row["driverId"] == "verstappen"
+    assert row["constructorId"] == "red_bull"
+    assert row["grid"] == 1 and row["position"] == 1
+    assert row["points"] == pytest.approx(25.0)
+    assert row["lat"] == pytest.approx(26.0) and row["lon"] == pytest.approx(50.5)
+    assert isinstance(row["date"], datetime) and row["date"].tzinfo is not None
+
+
+def test_parse_races_block_qualifying_and_sprint_labels():
+    qblock = [{
+        "season": "2023", "round": "2", "date": "2023-03-12", "time": "13:00:00Z",
+        "Circuit": {"circuitName": "Jeddah", "circuitId": "jeddah", "Location": {}},
+        "QualifyingResults": [{
+            "Driver": {"driverId": "leclerc", "code": "LEC"},
+            "Constructor": {"constructorId": "ferrari"},
+            "position": "1", "Q1": "1:28.0", "Q2": "1:27.5", "Q3": "1:27.0",
+        }],
+    }]
+    qrows = _parse_races_block(qblock, "qualifying", REF)
+    assert qrows[0]["session"] == "qualifying"
+    assert qrows[0]["qpos"] == 1
+    assert qrows[0]["q3"] == "1:27.0"
+
+    sblock = [{
+        "season": "2023", "round": "3", "date": "2023-04-29", "time": "15:00:00Z",
+        "Circuit": {"circuitName": "Baku", "circuitId": "baku", "Location": {}},
+        "SprintResults": [{
+            "Driver": {"driverId": "perez", "code": "PER"},
+            "Constructor": {"constructorId": "red_bull"}, "position": "2",
+        }],
+    }]
+    srows = _parse_races_block(sblock, "sprint", REF)
+    assert srows[0]["session"] == "sprint"
+    assert srows[0]["position"] == 2
+
+
+def test_parse_races_block_skips_rows_after_cutoff_and_without_round():
+    block = [
+        {"date": "2023-01-01"},  # no round -> skipped
+        {  # future date relative to a tighter cutoff -> skipped
+            "season": "2023", "round": "9", "date": "2023-12-31", "time": "00:00:00Z",
+            "Circuit": {"Location": {}}, "Results": [],
+        },
+    ]
+    cutoff = datetime(2023, 6, 1, tzinfo=timezone.utc)
+    assert _parse_races_block(block, "race", cutoff) == []
+
+
+def test_parse_races_block_malformed_date_falls_back_to_epoch():
+    block = [{
+        "season": "2023", "round": "1", "date": "not-a-date", "time": "nope",
+        "Circuit": {"circuitId": "x", "Location": {}},
+        "Results": [{"Driver": {"driverId": "a"}, "Constructor": {},
+                     "position": "1", "status": "Finished"}],
+    }]
+    rows = _parse_races_block(block, "race", REF)
+    # Epoch fallback (1970) is before REF, so the row survives with that date.
+    assert len(rows) == 1
+    assert rows[0]["date"].year == 1970

--- a/tests/test_jolpica_endpoints.py
+++ b/tests/test_jolpica_endpoints.py
@@ -1,6 +1,45 @@
 import unittest
 from unittest.mock import MagicMock
+
+import pytest
+
 from f1pred.data.jolpica import JolpicaClient
+
+
+# The three bulk season endpoints (race / qualifying / sprint) share an
+# identical paginate-then-merge-by-round implementation; the only differences
+# are the endpoint path and the per-round results key. Parametrising over that
+# (method, key) pair exercises the merge logic for all three without three
+# copy-pasted test bodies.
+@pytest.mark.parametrize(
+    "method_name, results_key",
+    [
+        ("get_season_race_results", "Results"),
+        ("get_season_qualifying_results", "QualifyingResults"),
+        ("get_season_sprint_results", "SprintResults"),
+    ],
+)
+def test_get_season_bulk_results_merge_by_round(method_name, results_key):
+    client = JolpicaClient("http://mock")
+    # Round 1 appears on two pages (must be merged into 2 entries); round 2 on one.
+    client._fetch_paginated_parallel = MagicMock(return_value=[
+        {"RaceTable": {"Races": [{"round": "1", results_key: [{"position": "1"}]}]}},
+        {"RaceTable": {"Races": [
+            {"round": "1", results_key: [{"position": "2"}]},
+            {"round": "2", results_key: [{"position": "1"}]},
+        ]}},
+    ])
+    results = getattr(client, method_name)("2021")
+    assert len(results) == 2
+
+    round1 = next((r for r in results if r["round"] == "1"), None)
+    assert round1 is not None
+    assert len(round1[results_key]) == 2  # merged across pages
+
+    round2 = next((r for r in results if r["round"] == "2"), None)
+    assert round2 is not None
+    assert len(round2[results_key]) == 1
+
 
 class TestJolpicaEndpoints(unittest.TestCase):
     def test_get_seasons(self):
@@ -41,51 +80,6 @@ class TestJolpicaEndpoints(unittest.TestCase):
         client.get_season_schedule.side_effect = Exception("API Error")
         event_error = client.get_event("2021", "1")
         self.assertIsNone(event_error)
-
-    def test_get_season_race_results(self):
-        client = JolpicaClient("http://mock")
-        client._fetch_paginated_parallel = MagicMock(return_value=[
-            {"RaceTable": {"Races": [{"round": "1", "Results": [{"position": "1"}]}]}},
-            {"RaceTable": {"Races": [{"round": "1", "Results": [{"position": "2"}]}, {"round": "2", "Results": [{"position": "1"}]}]}}
-        ])
-        results = client.get_season_race_results("2021")
-        self.assertEqual(len(results), 2)
-
-        # Round 1 should have 2 results merged
-        round1 = next((r for r in results if r["round"] == "1"), None)
-        self.assertIsNotNone(round1)
-        self.assertEqual(len(round1["Results"]), 2)
-
-        # Round 2 should have 1 result
-        round2 = next((r for r in results if r["round"] == "2"), None)
-        self.assertIsNotNone(round2)
-        self.assertEqual(len(round2["Results"]), 1)
-
-    def test_get_season_qualifying_results(self):
-        client = JolpicaClient("http://mock")
-        client._fetch_paginated_parallel = MagicMock(return_value=[
-            {"RaceTable": {"Races": [{"round": "1", "QualifyingResults": [{"position": "1"}]}]}},
-            {"RaceTable": {"Races": [{"round": "1", "QualifyingResults": [{"position": "2"}]}, {"round": "2", "QualifyingResults": [{"position": "1"}]}]}}
-        ])
-        results = client.get_season_qualifying_results("2021")
-        self.assertEqual(len(results), 2)
-
-        round1 = next((r for r in results if r["round"] == "1"), None)
-        self.assertIsNotNone(round1)
-        self.assertEqual(len(round1["QualifyingResults"]), 2)
-
-    def test_get_season_sprint_results(self):
-        client = JolpicaClient("http://mock")
-        client._fetch_paginated_parallel = MagicMock(return_value=[
-            {"RaceTable": {"Races": [{"round": "1", "SprintResults": [{"position": "1"}]}]}},
-            {"RaceTable": {"Races": [{"round": "1", "SprintResults": [{"position": "2"}]}, {"round": "2", "SprintResults": [{"position": "1"}]}]}}
-        ])
-        results = client.get_season_sprint_results("2021")
-        self.assertEqual(len(results), 2)
-
-        round1 = next((r for r in results if r["round"] == "1"), None)
-        self.assertIsNotNone(round1)
-        self.assertEqual(len(round1["SprintResults"]), 2)
 
     def test_get_race_results(self):
         client = JolpicaClient("http://mock")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,7 @@
 """Tests for model training and prediction."""
 import numpy as np
 import pandas as pd
+import pytest
 from datetime import datetime, timezone, timedelta
 from f1pred.models import train_pace_model, estimate_dnf_probabilities, build_hist_training_X
 
@@ -96,6 +97,71 @@ def test_build_hist_training_X_basic():
     assert len(result) > 0
     # All numeric columns from X_current should be present
     assert "grid" in result.columns
+
+
+def _two_season_history():
+    """Two full seasons (race/sprint/quali/sprint-quali) for 8 drivers, with the
+    finishing order flipped between seasons so a current-season boost has a
+    direction to move the index in. Enough rows to clear the 40-row / 20-finish
+    gates in build_hist_training_X.
+    """
+    drivers = [f"driver_{i}" for i in range(1, 9)]
+    base = datetime(2022, 3, 1, tzinfo=timezone.utc)
+    rows = []
+    for si, season in enumerate([2022, 2023]):
+        for rnd in range(1, 7):
+            d = base + timedelta(days=365 * si + 14 * rnd)
+            for pos, drv in enumerate(drivers, start=1):
+                racepos = pos if season == 2022 else (9 - pos)  # flip per season
+                team = f"team_{(pos - 1) // 2}"
+                rows.append({"season": season, "round": rnd, "session": "race", "date": d,
+                             "driverId": drv, "constructorId": team, "position": racepos,
+                             "points": max(0, 26 - racepos * 2), "grid": racepos, "status": "Finished"})
+                rows.append({"season": season, "round": rnd, "session": "sprint", "date": d,
+                             "driverId": drv, "constructorId": team, "position": racepos,
+                             "points": max(0, 9 - racepos), "grid": racepos, "status": "Finished"})
+                rows.append({"season": season, "round": rnd, "session": "qualifying", "date": d,
+                             "driverId": drv, "constructorId": team, "qpos": racepos})
+                rows.append({"season": season, "round": rnd, "session": "sprint_qualifying", "date": d,
+                             "driverId": drv, "constructorId": team, "qpos": racepos})
+    hist = pd.DataFrame(rows)
+    X_current = pd.DataFrame({
+        "driverId": drivers,
+        "constructorId": [f"team_{i // 2}" for i in range(8)],
+        "form_index": np.zeros(8),
+        "grid": list(range(1, 9)),
+    })
+    ref = datetime(2023, 3, 1, tzinfo=timezone.utc) + timedelta(days=300)
+    return hist, X_current, ref
+
+
+@pytest.mark.parametrize(
+    "boost_kwarg, affected_col",
+    [
+        ("boost_factor", "form_index"),
+        ("qual_boost_factor", "qualifying_form_index"),
+        ("sprint_boost_factor", "sprint_form_index"),
+    ],
+)
+def test_build_hist_training_X_boost_factors_are_wired_through(boost_kwarg, affected_col):
+    """Each of the three current-season boost factors must actually re-weight
+    its own index. The three boost-application blocks are near-identical, so a
+    typo (e.g. applying the race boost where the sprint boost belongs) would go
+    unnoticed without exercising each knob independently.
+    """
+    hist, X_current, ref = _two_season_history()
+
+    base = build_hist_training_X(hist, X_current, ref)
+    boosted = build_hist_training_X(hist, X_current, ref, **{boost_kwarg: 10.0})
+
+    assert base is not None and boosted is not None
+    assert affected_col in base.columns
+    # The boost must move the index it governs, and keep everything finite.
+    assert not np.allclose(base[affected_col].values, boosted[affected_col].values), (
+        f"{boost_kwarg} did not change {affected_col} — boost not wired to its index"
+    )
+    for col in boosted.select_dtypes("number").columns:
+        assert np.all(np.isfinite(boosted[col].values))
 
 
 def test_build_hist_training_X_insufficient_history():

--- a/tests/test_roster_malformed_entries.py
+++ b/tests/test_roster_malformed_entries.py
@@ -683,7 +683,11 @@ class TestRosterSizeIsUnconstrained:
         jc.get_latest_season_and_round.return_value = ("2025", "22")
         return jc
 
-    @pytest.mark.parametrize("n", [20, 21, 22, 24, 26])
+    # Two representative grid sizes per path are enough to prove "no cap":
+    # a current-era 22-car grid and the historical maximum of 26. Likewise
+    # below, n=14 (Spa 2021) and n=1 (degenerate) prove "no floor". Sweeping
+    # every value in between exercised the identical no-truncation code path.
+    @pytest.mark.parametrize("n", [22, 26])
     def test_previous_round_preserves_full_grid(self, n):
         """A future event whose previous completed round had n drivers must
         return exactly n drivers, for any grid size.
@@ -717,7 +721,7 @@ class TestRosterSizeIsUnconstrained:
             "grid size must not be capped"
         )
 
-    @pytest.mark.parametrize("n", [20, 22, 24])
+    @pytest.mark.parametrize("n", [22, 26])
     def test_same_round_race_results_preserve_full_grid(self, n):
         """When Jolpica returns classified race results for the round, every
         driver (even >20) must be returned unchanged.
@@ -732,7 +736,7 @@ class TestRosterSizeIsUnconstrained:
 
         assert len(roster) == n
 
-    @pytest.mark.parametrize("n", [20, 22, 24])
+    @pytest.mark.parametrize("n", [22, 26])
     def test_fastf1_race_session_preserves_full_grid(self, n):
         """A completed 22- or 24-driver FastF1 Race session must be returned
         whole. Practice-session reserve filtering is the only legitimate
@@ -768,7 +772,7 @@ class TestRosterSizeIsUnconstrained:
 
     # -- No minimum: DSQ / not-classified scenarios must be accepted --------
 
-    @pytest.mark.parametrize("n", [1, 5, 10, 14, 17])
+    @pytest.mark.parametrize("n", [1, 14])
     def test_same_round_accepts_below_20_drivers(self, n):
         """Jolpica returning a small classification (because of mass DSQ,
         DNS, or not-classified) MUST be accepted at face value. The old
@@ -789,7 +793,7 @@ class TestRosterSizeIsUnconstrained:
             "— roster must have no minimum-count gate."
         )
 
-    @pytest.mark.parametrize("n", [1, 5, 10, 14, 17])
+    @pytest.mark.parametrize("n", [1, 14])
     def test_fastf1_authoritative_accepts_below_20_drivers(self, n):
         """A classified Race session with fewer than 20 drivers (after
         widespread DSQ or mechanical carnage) must be returned as-is. There


### PR DESCRIPTION
## Summary

Acts on the deferred items called out in the test-suite audit (#449). Three fronts: **close the biggest coverage gap (features.py)**, **de-duplicate copy-pasted tests**, and **stop a browser suite from silently never running**.

Overall coverage **74.47% → 77.21%** (floor raised 73.0% → 76.0%). Suite green: **500 passed**.

## Coverage: features.py 43.6% → 60.3%

`features.py` was the largest remaining gap. The per-driver feature builders were only exercised transitively (if at all) through the heavily-mocked `build_session_features` path, which never asserted on their numeric output. New `tests/test_feature_computations.py` pins the actual maths — for a single historical event the recency weight cancels, so each index reduces to a closed form asserted exactly:

| Function | What's asserted |
|----------|-----------------|
| `compute_form_indices` | `form_index == -position`; sprint sessions included; current-season `boost_factor` reweights toward the recent result; empty-frame contract |
| `compute_sprint_form` | `-position + points`; empty when no sprint sessions |
| `compute_qualifying_form` / `compute_sprint_qualifying_form` | `-qpos`; spans both quali types / ignores plain qualifying; missing-`qpos` contract |
| `compute_circuit_proficiency` | experience / avg-finish / DNF-rate; circuit + ref-date filtering; missing-column & blank-id contracts |
| `compute_circuit_globals` | overtake difficulty `mean(grid - finish)`; DNF rate; neutral defaults on no history |
| `compute_grid_finish_delta` | `grid - position`; ignores non-race sessions |
| `_parse_races_block` | race/qualifying/sprint row normalisation; cutoff + missing-round skipping; malformed-date epoch fallback |

Plus a parametrised `test_build_hist_training_X_boost_factors_are_wired_through` that drives a two-season synthetic history and verifies each of the three near-identical current-season boost blocks (race / qualifying / sprint) re-weights **its own** index — a copy-paste typo applying the wrong boost would now fail.

## De-duplication

- **jolpica bulk endpoints:** the three near-identical `test_get_season_{race,qualifying,sprint}_results` merge tests collapsed into one `test_get_season_bulk_results_merge_by_round` parametrised over `(method, results_key)`. Same paginate-then-merge-by-round assertions, one body.
- **`TestRosterSizeIsUnconstrained`:** trimmed the parametrize sweeps from **21 → 10** cases. Every distinct code path (previous-round / same-round / FastF1 / below-20 jolpica / below-20 FastF1) is still covered; the redundant in-between grid sizes all hit the identical no-truncation logic. Kept two representative sizes per path — a current-era value and an extreme (26 for "no cap", 1 for "no floor").

## Browser e2e split

The two Playwright tests (`test_ui_fix.py`, `test_ui_layout.py`) skipped whenever `CI=true` and required a browser, so they **never executed** in CI yet still showed up as skips in the default suite. Moved them to a dedicated `e2e/` directory (not collected by `make test` / `pytest tests/`) with a `README.md` documenting the manual runner (`pip install pytest-playwright && playwright install chromium && pytest e2e/`). Dropped the `CI=true` skip, kept the graceful playwright-availability guard.

## Not done

The remaining `features.py` lines (the big `build_session_features` orchestrator and weather-sensitivity regression) and `predict.py` / `web.py` would need heavier fixtures or live-ish integration harnesses — out of scope for this pass.

https://claude.ai/code/session_016DrpGRTkkeHzGooeNkKT7v

---
_Generated by [Claude Code](https://claude.ai/code/session_016DrpGRTkkeHzGooeNkKT7v)_