### PR TITLE
🎨 Palette: [UX improvement] Add required form field indicators and disabled button tooltips

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-11 - "Settings" Navigation Tab Role
 **Learning:** The navigation tabs in `index.html` (e.g., "Predictions" and "Settings" buttons around line 180) currently lack ARIA `role="tab"` attributes. When writing automated Playwright tests, `page.get_by_role("tab", name="Settings")` will fail to find the button.
 **Action:** When testing these tabs, use text-based locators like `page.locator("button:has-text('Settings')")` instead, or propose a separate UX improvement to add proper ARIA tablist/tab roles to this navigation structure.
+
+## 2025-02-24 - Form validation required indicators
+**Learning:** A common UX/A11y pattern is explicitly marking `required` form fields. While `required` attributes ensure client-side validation logic catches empty fields, without a visual indicator (like a red asterisk `*`) users may only discover the field is required *after* a failed submission.
+**Action:** Always pair `required` inputs with explicit visual indicators (like `<span class="text-red-500">*</span>`) appended to the associated `<label>` element, and provide helpful tooltips on disabled actionable elements.

--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -648,12 +648,12 @@
 
                         <form @submit.prevent="login" class="space-y-5">
                             <div>
-                                <label for="login-username" class="block text-sm font-medium text-gray-300">Username</label>
+                                <label for="login-username" class="block text-sm font-medium text-gray-300">Username <span class="text-red-500">*</span></label>
                                 <input id="login-username" type="text" x-model="authUsername" required
                                     class="mt-1 block w-full bg-gray-900 border border-gray-700 rounded-md shadow-sm py-2 px-3 text-sm focus:outline-none focus:ring-1 focus:ring-red-500 focus:border-red-500 text-white">
                             </div>
                             <div>
-                                <label for="login-password" class="block text-sm font-medium text-gray-300">Password</label>
+                                <label for="login-password" class="block text-sm font-medium text-gray-300">Password <span class="text-red-500">*</span></label>
                                 <input id="login-password" type="password" x-model="authPassword" required
                                     class="mt-1 block w-full bg-gray-900 border border-gray-700 rounded-md shadow-sm py-2 px-3 text-sm focus:outline-none focus:ring-1 focus:ring-red-500 focus:border-red-500 text-white">
                             </div>
@@ -681,12 +681,12 @@
 
                                     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                                         <div>
-                                            <label for="current-password" class="block text-xs font-medium text-gray-400 mb-1">Current Password</label>
+                                            <label for="current-password" class="block text-xs font-medium text-gray-400 mb-1">Current Password <span class="text-red-500">*</span></label>
                                             <input id="current-password" type="password" x-model="passChange.current" required
                                                 class="block w-full bg-gray-800 border border-gray-600 rounded-md shadow-sm py-1.5 px-3 text-xs focus:outline-none focus:ring-1 focus:ring-red-500 focus:border-red-500 text-white">
                                         </div>
                                         <div>
-                                            <label for="new-password" class="block text-xs font-medium text-gray-400 mb-1">New Password</label>
+                                            <label for="new-password" class="block text-xs font-medium text-gray-400 mb-1">New Password <span class="text-red-500">*</span></label>
                                             <input id="new-password" type="password" x-model="passChange.new" required
                                                 class="block w-full bg-gray-800 border border-gray-600 rounded-md shadow-sm py-1.5 px-3 text-xs focus:outline-none focus:ring-1 focus:ring-red-500 focus:border-red-500 text-white">
                                         </div>
@@ -709,6 +709,7 @@
                                         <input id="discord-webhook-url" type="text" x-model="settings.discord_webhook_url" placeholder="https://discord.com/api/webhooks/..."
                                             class="block w-full bg-gray-800 border border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm focus:outline-none focus:ring-1 focus:ring-red-500 focus:border-red-500 text-white">
                                         <button type="button" @click="testWebhook" :disabled="webhookTesting || !settings.discord_webhook_url"
+                                            :title="!settings.discord_webhook_url ? 'Please enter a webhook URL first' : 'Test webhook'"
                                             class="bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white text-xs py-1 px-4 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white flex-shrink-0">
                                             <span x-show="!webhookTesting">Test</span>
                                             <span x-show="webhookTesting"><i class="fas fa-circle-notch fa-spin"></i></span>


### PR DESCRIPTION
💡 What: Added visual `*` indicators to all required form fields in the Settings tab (Username, Password, Current Password, New Password) and a dynamic `:title` tooltip to the disabled "Test" webhook button.
🎯 Why: To improve usability and accessibility by clearly denoting required fields so users don't have to wait for a failed submission to know a field is required, and explaining why an action is blocked.
📸 Before/After: See PR attachments.
♿ Accessibility: Explicitly pairing visual indicators with required form inputs significantly improves screen reader and cognitive accessibility by clearly setting expectations before form submission.

---
*PR created automatically by Jules for task [13879918879077796972](https://jules.google.com/task/13879918879077796972) started by @2fst4u*