### PR TITLE
🧪 Spec: [Add] PredictionCache and fingerprint tests

### DIFF
--- a/.jules/spec.md
+++ b/.jules/spec.md
@@ -6,3 +6,8 @@ When attempting to mock functions that are locally imported within a method's bo
 When an application's data transformations (e.g., rounding) crash on `None` values (like `math.isnan`), do not alter the application code to handle the `None` just so a test can assert how it behaves. Instead, write tests that pass valid types or verify the exception is handled upstream if that is the intended behavior.
 ## 2024-05-18 - PredictionCache Mocking and Coverage
 When adding tests to `PredictionCache` (in `f1pred/util.py`) for the explicit `get_by_key` and `set_by_key` methods, you must mock `hashlib.sha256` to force a write error for testing error handling since standard OS/file permissions can be tricky to guarantee a write failure across all environments safely.
+## 2024-05-19 - Safe state mutation in Pytest
+When testing logic that involves global state modification (e.g., clearing `f1pred.util._LOGIC_FINGERPRINT` to verify caching behavior), strictly prefer using Pytest's `monkeypatch` fixture over manual state backup/restore via `try...finally` blocks to maintain robustness and test isolation.
+
+## 2024-05-19 - Deterministic file-based test assertions
+When testing file eviction policies (like in `PredictionCache` where the oldest file is deleted), avoid relying on `time.sleep()` to generate deterministic file timestamps, as this introduces flakiness depending on the underlying filesystem's timestamp resolution. Instead, monkeypatch the timestamp retrieval function (e.g. `os.path.getmtime`) to enforce deterministic file ordering safely within the test.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,6 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 76.00
+fail_under = 76.10
 show_missing = true
 precision = 2

--- a/tests/test_prediction_cache.py
+++ b/tests/test_prediction_cache.py
@@ -82,3 +82,39 @@ def test_prediction_cache_key_stability(tmp_path):
     res = {"val": 42}
     cache.set(inputs1, res)
     assert cache.get(inputs2) == res
+
+def test_prediction_cache_eviction_unlink_failure(tmp_path, monkeypatch):
+    import os
+    cache_dir = tmp_path / "cache"
+    cache = PredictionCache(str(cache_dir), max_entries=2)
+
+    cache.set({"v": 1}, {"res": 1})
+    cache.set({"v": 2}, {"res": 2})
+
+    # Monkeypatch os.path.getmtime to ensure deterministic ordering
+    # so we know which file will be evicted without relying on system clock
+    mtime_mapping = {}
+    files = list(cache_dir.glob("*.json"))
+    if len(files) == 2:
+        mtime_mapping[str(files[0])] = 1000.0
+        mtime_mapping[str(files[1])] = 2000.0
+
+    original_getmtime = os.path.getmtime
+    def mock_getmtime(path):
+        return mtime_mapping.get(str(path), original_getmtime(path))
+
+    monkeypatch.setattr(os.path, "getmtime", mock_getmtime)
+
+    # Monkeypatch unlink to fail
+    def mock_unlink(*args, **kwargs):
+        raise OSError("Permission denied")
+
+    from pathlib import Path
+    monkeypatch.setattr(Path, "unlink", mock_unlink)
+
+    # Adding a 3rd should trigger eviction of the oldest
+    # But unlink fails, which is silently swallowed
+    cache.set({"v": 3}, {"res": 3})
+
+    # Ensure it didn't crash
+    assert cache.get({"v": 3}) is not None

--- a/tests/test_util_core.py
+++ b/tests/test_util_core.py
@@ -61,3 +61,29 @@ def test_init_caches_disabled():
     # a global cache.
     assert result is None
     assert requests_cache.is_installed() == before
+
+import pytest
+import hashlib
+from unittest.mock import patch, MagicMock
+from f1pred.util import logic_fingerprint
+
+def test_logic_fingerprint(monkeypatch):
+    import f1pred.util
+    monkeypatch.setattr(f1pred.util, "_LOGIC_FINGERPRINT", None)
+
+    fp1 = logic_fingerprint()
+    assert len(fp1) == 12
+
+    fp2 = logic_fingerprint()
+    assert fp1 == fp2
+
+@patch('f1pred.util.Path.read_bytes')
+def test_logic_fingerprint_missing_file(mock_read_bytes, monkeypatch):
+    import f1pred.util
+    monkeypatch.setattr(f1pred.util, "_LOGIC_FINGERPRINT", None)
+
+    # Simulate missing file
+    mock_read_bytes.side_effect = FileNotFoundError()
+
+    fp = logic_fingerprint()
+    assert len(fp) == 12


### PR DESCRIPTION
💡 What: Wrote robust tests to cover the edge cases for `PredictionCache` eviction unlink failures and `logic_fingerprint` file read failures in `f1pred/util.py`. Refactored tests to use Pytest's `monkeypatch` rather than relying on brittle `time.sleep()` logic for filesystem assertions.
🎯 Why: `f1pred/util.py` had important cache eviction blocks missing coverage. Explicitly verifying that the cache handles silent `unlink` errors ensures robustness without introducing flaky state behavior into the test suite.
📈 Maturity Impact: Bumped coverage threshold in `pyproject.toml` from 76.00% to 76.10% to lock in progress toward business standards.

---
*PR created automatically by Jules for task [14343685183044653924](https://jules.google.com/task/14343685183044653924) started by @2fst4u*