### PR TITLE
📚 Archivist: Clarify undocumented app configuration settings

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -17,3 +17,7 @@
 ## 2024-05-24 - Documenting Weather Features
 **Learning:** Weather condition sensitivity features (`weather_beta_temp`, `weather_beta_pressure`, `weather_beta_wind`, `weather_beta_rain`) were added to the codebase but left undocumented in the README.md's "Input Variables" section, creating drift between the feature list and the actual implementation.
 **Action:** When adding new features or sensitivity parameters to `f1pred/predict.py`, always ensure they are fully documented in the `README.md` to keep the model's inputs fully transparent.
+
+## 2024-06-15 - Undocumented Configuration Drift
+**Learning:** Application-level configuration options defined in `f1pred/config.py` and `config.yaml` (such as `live_refresh_seconds`, `auto_refresh_seconds`, `timezone`, and `log_level`) frequently drift from the documented setup in `README.md`, causing users to be unaware of tweakable application parameters.
+**Action:** When auditing or modifying application configurations, always explicitly cross-reference and update the `README.md` Configuration section to prevent undocumented configuration drift.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ The model uses a variety of engineered features to capture driver talent, car pe
 All settings live in `config.yaml`. The main things you might want to tweak:
 
 ```yaml
+app:
+  live_refresh_seconds: 600   # Live mode poll interval (seconds)
+  auto_refresh_seconds: 3600  # Background prediction refresh interval (seconds)
+  timezone: "UTC"             # System timezone for session times
+  log_level: "WARNING"        # DEBUG, INFO, WARNING, ERROR
+
 modelling:
   # Model weights (including recency, blending, ensemble, DNF)
   # are dynamically calibrated at runtime.


### PR DESCRIPTION
💡 **Problem:** Important application-level configuration options (like `live_refresh_seconds`, `auto_refresh_seconds`, `timezone`, and `log_level`) existed in the `config.yaml` file and `f1pred/config.py` but were completely missing from the `README.md`'s Configuration section. This created configuration drift and left users unaware of these tweakable parameters.
🎯 **Fix:** Inserted an `app:` block containing these missing configuration fields into the `README.md` to perfectly match the actual available application configuration options.
🧪 **Verification:** Ran `make test` locally to ensure no logic was broken by the markdown changes, and verified that the layout of the markdown remains properly formatted.
🔎 **Scope:** This PR contains strictly documentation changes to `README.md` and a journal learning to `.jules/archivist.md`.

---
*PR created automatically by Jules for task [3245474562790628096](https://jules.google.com/task/3245474562790628096) started by @2fst4u*