### PR TITLE
🧹 Sweep: Remove unused _get_canonical_mapping function

### DIFF
--- a/f1pred/roster.py
+++ b/f1pred/roster.py
@@ -255,7 +255,7 @@ def _roster_from_round(jc: JolpicaClient, season: str, rnd: str) -> List[Dict]:
 def _build_canonical_mapping_from_entries(raw_entries: List[Dict]) -> Dict[str, 'Any']:  # noqa: F821
     """Build canonical-id lookup tables directly from a pre-fetched entry list.
 
-    Factored out of :func:`_get_canonical_mapping` so that callers who have
+    Factored out so that callers who have
     already fetched the entry list don't pay the network cost twice.
 
     Returns a dict with keys:
@@ -307,20 +307,6 @@ def _build_canonical_mapping_from_entries(raw_entries: List[Dict]) -> Dict[str, 
         "constructors": constructor_map,
         "race_driver_ids": race_driver_ids,
     }
-
-
-def _get_canonical_mapping(jc: JolpicaClient, season: str) -> Dict[str, 'Any']:  # noqa: F821
-    """Fetch season entry list and build canonical-id lookup tables."""
-    try:
-        raw_entries = jc.get_season_entry_list(season)
-    except Exception as e:
-        logger.warning(f"[roster] Failed to fetch canonical entry list: {e}")
-        return {}
-    try:
-        return _build_canonical_mapping_from_entries(raw_entries or [])
-    except Exception as e:
-        logger.warning(f"[roster] Failed to build canonical mapping: {e}")
-        return {}
 
 
 def _roster_entries_from_fastf1_results(

--- a/tests/test_roster_fix.py
+++ b/tests/test_roster_fix.py
@@ -57,9 +57,6 @@ def test_roster_derivation_prefers_later_sessions():
     mock_event.get_session.side_effect = get_session_mock
 
     with patch("f1pred.data.fastf1_backend.get_event", return_value=mock_event):
-        # We need to mock _get_canonical_mapping to return something that won't fail
-        # Or just let it return empty dict, and it will use Abbreviations.
-
         roster = derive_roster(jc, "2026", "4")
 
         # Currently, it picks FP1 first because it iterates ["FP1", "Qualifying", ...]

--- a/tests/test_roster_mapping.py
+++ b/tests/test_roster_mapping.py
@@ -1,54 +1,6 @@
 import pandas as pd
 from unittest.mock import MagicMock, patch
-from f1pred.roster import _get_canonical_mapping, _roster_from_fastf1
-
-def test_get_canonical_mapping():
-    jc = MagicMock()
-    jc.get_season_entry_list.return_value = [
-        {
-            "Driver": {
-                "driverId": "max_verstappen",
-                "permanentNumber": "1",
-                "code": "VER",
-                "givenName": "Max",
-                "familyName": "Verstappen"
-            },
-            "Constructor": {
-                "constructorId": "red_bull",
-                "name": "Red Bull Racing"
-            }
-        },
-        {
-            "Driver": {
-                "driverId": "lando_norris",
-                "permanentNumber": "4",
-                "code": "NOR",
-                "givenName": "Lando",
-                "familyName": "Norris"
-            },
-            "Constructor": {
-                "constructorId": "mclaren",
-                "name": "McLaren"
-            }
-        }
-    ]
-
-    mapping = _get_canonical_mapping(jc, "2024")
-
-    assert "drivers" in mapping
-    assert "constructors" in mapping
-
-    # Check driver mapping by various keys
-    assert mapping["drivers"]["1"] == "max_verstappen"
-    assert mapping["drivers"]["VER"] == "max_verstappen"
-    assert mapping["drivers"]["max verstappen"] == "max_verstappen"
-    assert mapping["drivers"]["4"] == "lando_norris"
-    assert mapping["drivers"]["NOR"] == "lando_norris"
-    assert mapping["drivers"]["lando norris"] == "lando_norris"
-
-    # Check constructor mapping
-    assert mapping["constructors"]["red bull racing"] == "red_bull"
-    assert mapping["constructors"]["mclaren"] == "mclaren"
+from f1pred.roster import _roster_from_fastf1
 
 @patch("f1pred.data.fastf1_backend.get_event")
 def test_roster_from_fastf1_with_mapping(mock_get_event):


### PR DESCRIPTION
💡 **What**:
- Removed the `_get_canonical_mapping` function from `f1pred/roster.py`.
- Updated the docstring of `_build_canonical_mapping_from_entries` that previously referenced the removed function.
- Deleted `test_get_canonical_mapping` and its associated import from `tests/test_roster_mapping.py`.
- Removed an unused mock referencing `_get_canonical_mapping` from `tests/test_roster_fix.py`.

🎯 **Why**:
- The `_get_canonical_mapping` function was dead code identified by `vulture`. It was no longer being called anywhere within the module or the broader application. Removing it reduces repository bloat and cognitive overhead.

🔬 **Verification**:
- Verified the function was unreferenced using `grep -rn "_get_canonical_mapping" .` across the workspace.
- Ran `make test` locally to ensure the test suite passes successfully.

---
*PR created automatically by Jules for task [299601432401538351](https://jules.google.com/task/299601432401538351) started by @2fst4u*