### PR TITLE
📚 Archivist: Update Configuration docs with missing feature flags

### DIFF
--- a/.jules/archivist.md
+++ b/.jules/archivist.md
@@ -21,3 +21,7 @@
 ## 2024-06-15 - Undocumented Configuration Drift
 **Learning:** Application-level configuration options defined in `f1pred/config.py` and `config.yaml` (such as `live_refresh_seconds`, `auto_refresh_seconds`, `timezone`, and `log_level`) frequently drift from the documented setup in `README.md`, causing users to be unaware of tweakable application parameters.
 **Action:** When auditing or modifying application configurations, always explicitly cross-reference and update the `README.md` Configuration section to prevent undocumented configuration drift.
+
+## 2026-06-10 - Undocumented Feature Flags in Configuration
+**Learning:** Feature toggles in the `modelling.features` section of `config.yaml` (such as `include_fastf1_fill`, `include_circuit_elevation`, and `include_weather_ensemble`) often drift from the `README.md` documentation. When new modeling features are introduced, developers update `config.py` and `config.yaml` but forget to document these flags in the `README.md` Configuration section.
+**Action:** When adding new feature flags or modeling configurations, always update the Configuration section in `README.md` to match the actual `config.yaml` defaults and provide visibility to users.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ modelling:
   # Delete calibration_weights.json to force full re-calibration.
   monte_carlo:
     draws: 5000 # Simulation iterations (more = slower but smoother)
+  features:
+    include_fastf1_fill: true
+    include_circuit_elevation: true
+    include_weather_ensemble: true
 
 data_sources:
   open_meteo:


### PR DESCRIPTION
💡 Problem: The `README.md` documentation regarding configuration flags under the `modelling.features` section drifted from `config.yaml` and `f1pred/config.py`. Flags like `include_fastf1_fill`, `include_circuit_elevation`, and `include_weather_ensemble` were undocumented, causing users to miss tweakable configuration options.

🎯 Fix: Added the missing `features` block containing `include_fastf1_fill`, `include_circuit_elevation`, and `include_weather_ensemble` under the `modelling` section in `README.md` to accurately reflect the default configuration and system capabilities. Also logged this config drift occurrence in `.jules/archivist.md`.

🧪 Verification: Cross-referenced the `config.yaml` and `f1pred/config.py` definitions and ran the test suite (`make test`) which passed successfully ensuring no negative impacts.

🔎 Scope: This PR is strictly limited to documentation updates (`README.md`) and persona logging (`.jules/archivist.md`).

---
*PR created automatically by Jules for task [5413866322322850134](https://jules.google.com/task/5413866322322850134) started by @2fst4u*