### PR TITLE
Comment on commits with dev build info

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,3 +135,15 @@ jobs:
           labels: ${{ steps.version.outputs.is_release == 'true' && steps.meta-release.outputs.labels || steps.meta-dev.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Comment on commit with dev build info
+        if: steps.version.outputs.is_release == 'false'
+        uses: peter-evans/commit-comment@v3
+        with:
+          sha: ${{ github.sha }}
+          body: |
+            :package: Dev build [`v${{ steps.version.outputs.version }}`](https://github.com/${{ github.repository }}/pkgs/container/${{ github.event.repository.name }}) published.
+
+            ```
+            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+            ```


### PR DESCRIPTION
## Summary
- After a dev build is built and pushed, post a comment on the triggering commit with the dev build version (`vX.Y.Z-dev.N`) and a `docker pull` command for the published image — tying each commit to its dev build, similar to pivot-tactical.

## Test plan
- [ ] Push a commit to a non-main branch and confirm a commit comment appears with the dev version and pull command after the build succeeds.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D8XHobhcYdFtBaQqCbccHw)_