### PR TITLE
Fix stable + dev container publishing (release trigger; commit-comment 403)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,11 @@ jobs:
     needs: [tests]
     if: needs.tests.result == 'success'
     permissions:
-      contents: read
+      # contents: write is required by the dev-build commit-comment step below
+      # (creating a commit comment needs write access). The release path is
+      # called via workflow_call from release.yml, which caps this to read —
+      # that's fine because the comment step is skipped for releases.
+      contents: write
       packages: write
 
     steps:
@@ -153,6 +157,9 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Comment on commit with dev build info
+        # The commit comment is a cosmetic notification — never let it fail an
+        # otherwise-successful build and image push.
+        continue-on-error: true
         if: steps.version.outputs.is_release == 'false'
         uses: peter-evans/commit-comment@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,11 @@ on:
       - "**.md"
       - "docs/**"
       - ".github/workflows/**"
+  # Stable builds are triggered by publishing a GitHub Release (e.g. from the
+  # "Draft a new release" UI). A release published by a human fires this event;
+  # the image is built and tagged from the release's tag.
+  release:
+    types: [published]
   workflow_call:
     inputs:
       is_release:
@@ -60,8 +65,18 @@ jobs:
           MINOR=$(echo "$VERSION" | cut -d. -f2)
           PATCH=$(echo "$VERSION" | cut -d. -f3)
 
-          if [ "${{ inputs.is_release }}" = "true" ]; then
+          # A stable release build is triggered either by publishing a GitHub
+          # Release (release event) or by release.yml calling this workflow
+          # (workflow_call with is_release=true). Both supply the release tag.
+          if [ "${{ github.event_name }}" = "release" ]; then
+            RELEASE_TAG="${{ github.event.release.tag_name }}"
+          elif [ "${{ inputs.is_release }}" = "true" ]; then
             RELEASE_TAG="${{ inputs.release_tag }}"
+          else
+            RELEASE_TAG=""
+          fi
+
+          if [ -n "$RELEASE_TAG" ]; then
             echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
             echo "is_release=true" >> "$GITHUB_OUTPUT"
             echo "Release version: ${RELEASE_TAG#v}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,22 @@ on:
           - major
         default: patch
 
+# A release must be atomic: the git tag and GitHub Release are only published
+# AFTER the Docker image has been built and pushed. Previously the tag/release
+# were created first and the image was built in a separate downstream job, so any
+# build failure (including a flaky second test run tripping the coverage gate)
+# left a published "stable release" with no corresponding container image.
+#
+# Flow: version -> build-release (runs tests, then builds & pushes image) ->
+# publish (creates tag + GitHub Release). Tests run exactly once, inside
+# build.yml, where they gate the image build.
 jobs:
-  tests:
-    name: "Tests"
-    uses: ./.github/workflows/tests.yml
-
-  release:
-    name: "Release"
-    needs: tests
+  # Resolve the next version up-front from the existing stable tags so the image
+  # can be built and tagged before the new git tag exists. build.yml injects this
+  # version into the build, so the tag itself is not required at build time.
+  version:
+    name: "Resolve next version"
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     outputs:
       version: ${{ steps.next.outputs.version }}
 
@@ -76,27 +81,46 @@ jobs:
           echo "version=$NEXT" >> "$GITHUB_OUTPUT"
           echo "Next version: $NEXT (bump=$BUMP)"
 
+  # Build & push the release image. build.yml runs the test suite before building,
+  # so this gates the entire release on a green test run and a successful image
+  # push. If anything here fails, no tag or GitHub Release is created.
+  build-release:
+    name: "Build Release Image"
+    needs: version
+    uses: ./.github/workflows/build.yml
+    with:
+      is_release: true
+      release_tag: ${{ needs.version.outputs.version }}
+    permissions:
+      contents: read
+      packages: write
+
+  # Only tag the commit and publish the GitHub Release once the image exists.
+  publish:
+    name: "Publish Release"
+    needs: [version, build-release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
+        with:
+          ref: main
+          fetch-depth: 0
+          fetch-tags: true
+
       - name: Create and push tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ steps.next.outputs.version }}" -m "Release ${{ steps.next.outputs.version }}"
-          git push origin "${{ steps.next.outputs.version }}"
+          git tag -a "${{ needs.version.outputs.version }}" -m "Release ${{ needs.version.outputs.version }}"
+          git push origin "${{ needs.version.outputs.version }}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.next.outputs.version }}
-          name: ${{ steps.next.outputs.version }}
+          tag_name: ${{ needs.version.outputs.version }}
+          name: ${{ needs.version.outputs.version }}
           generate_release_notes: true
-
-  build-release:
-    name: "Build Release Image"
-    needs: release
-    uses: ./.github/workflows/build.yml
-    with:
-      is_release: true
-      release_tag: ${{ needs.release.outputs.version }}
-    permissions:
-      contents: read
-      packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,22 +13,17 @@ on:
           - major
         default: patch
 
-# A release must be atomic: the git tag and GitHub Release are only published
-# AFTER the Docker image has been built and pushed. Previously the tag/release
-# were created first and the image was built in a separate downstream job, so any
-# build failure (including a flaky second test run tripping the coverage gate)
-# left a published "stable release" with no corresponding container image.
-#
-# Flow: version -> build-release (runs tests, then builds & pushes image) ->
-# publish (creates tag + GitHub Release). Tests run exactly once, inside
-# build.yml, where they gate the image build.
 jobs:
-  # Resolve the next version up-front from the existing stable tags so the image
-  # can be built and tagged before the new git tag exists. build.yml injects this
-  # version into the build, so the tag itself is not required at build time.
-  version:
-    name: "Resolve next version"
+  tests:
+    name: "Tests"
+    uses: ./.github/workflows/tests.yml
+
+  release:
+    name: "Release"
+    needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.next.outputs.version }}
 
@@ -81,46 +76,27 @@ jobs:
           echo "version=$NEXT" >> "$GITHUB_OUTPUT"
           echo "Next version: $NEXT (bump=$BUMP)"
 
-  # Build & push the release image. build.yml runs the test suite before building,
-  # so this gates the entire release on a green test run and a successful image
-  # push. If anything here fails, no tag or GitHub Release is created.
-  build-release:
-    name: "Build Release Image"
-    needs: version
-    uses: ./.github/workflows/build.yml
-    with:
-      is_release: true
-      release_tag: ${{ needs.version.outputs.version }}
-    permissions:
-      contents: read
-      packages: write
-
-  # Only tag the commit and publish the GitHub Release once the image exists.
-  publish:
-    name: "Publish Release"
-    needs: [version, build-release]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.2.2
-        with:
-          ref: main
-          fetch-depth: 0
-          fetch-tags: true
-
       - name: Create and push tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ needs.version.outputs.version }}" -m "Release ${{ needs.version.outputs.version }}"
-          git push origin "${{ needs.version.outputs.version }}"
+          git tag -a "${{ steps.next.outputs.version }}" -m "Release ${{ steps.next.outputs.version }}"
+          git push origin "${{ steps.next.outputs.version }}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.version.outputs.version }}
-          name: ${{ needs.version.outputs.version }}
+          tag_name: ${{ steps.next.outputs.version }}
+          name: ${{ steps.next.outputs.version }}
           generate_release_notes: true
+
+  build-release:
+    name: "Build Release Image"
+    needs: release
+    uses: ./.github/workflows/build.yml
+    with:
+      is_release: true
+      release_tag: ${{ needs.release.outputs.version }}
+    permissions:
+      contents: read
+      packages: write

--- a/tests/test_release_config.py
+++ b/tests/test_release_config.py
@@ -57,6 +57,23 @@ class TestReleaseInfrastructure:
             "build.yml must trigger on push to ensure every commit is gated and build Docker images after tests pass"
         )
 
+    def test_build_workflow_triggers_on_release(self):
+        """build.yml must trigger on a published GitHub Release so that
+        manually publishing a release (e.g. from the 'Draft a new release' UI)
+        builds the stable container image."""
+        workflow = ROOT / ".github" / "workflows" / "build.yml"
+        content = workflow.read_text(encoding="utf-8")
+        parsed = yaml.safe_load(content)
+        triggers = parsed.get(True, {})
+        assert "release" in triggers, (
+            "build.yml must trigger on the 'release' event so a "
+            "manually published GitHub Release builds the stable image"
+        )
+        types = (triggers.get("release") or {}).get("types", [])
+        assert "published" in types, (
+            "build.yml's release trigger must fire on the 'published' type"
+        )
+
     def test_build_workflow_has_no_review_job(self):
         """build.yml must not define a review job. Code review is invoked
         manually via /oc-review (handled by opencode-review.yml), not as


### PR DESCRIPTION
## Problem

Two separate bugs were stopping containers from being published as intended:

### 1. Stable: no `release` trigger
Stable builds are meant to be triggered by **manually publishing a release** (GitHub "Draft a new release" UI). But `build.yml` had **no `release` trigger** — only `push` (dev) and `workflow_call` (used internally by the `Release` Action). So publishing a release from the UI built nothing, leaving `v0.2.1` with no container.

### 2. Dev: build job goes red on a cosmetic commit comment
The CI run on this PR (`27efa5c`) revealed the dev-side failure. The image **built and pushed successfully** (`v0.2.2-dev.2` was published to GHCR), then the job failed at the final `Comment on commit with dev build info` step:

```
POST /repos/2fst4u/f1predictor/commits/{sha}/comments
message: 'Resource not accessible by integration', status: '403'
```

Creating a commit comment needs `contents: write`, but `4a33d86` downgraded the build job to `contents: read` (when it removed dev-tag pushing) without accounting for the commit-comment step added in `fb674d3`. So **every dev build went red on a cosmetic notification even though the image was published.**

## Fix

- **`build.yml`: add `on: release: types: [published]`** and resolve the version from `github.event.release.tag_name` for release events (reusing the existing `is_release` / semver path). A human-published release fires this event, so manually creating a release now drives the stable build. `release.yml`'s `workflow_call` path is unchanged, so the automated `Release` Action still works (no double build — workflow-token-created releases don't fire the `release` event).
- **`build.yml`: restore `contents: write`** on the build job so the commit-comment step works, and mark that step **`continue-on-error`** so a cosmetic notification can never fail an otherwise-successful build + push. The release path (`workflow_call`, capped to `contents: read`) skips the comment, so it's unaffected.
- **`tests/test_release_config.py`: +1 test** asserting `build.yml` triggers on `release: published` (14 pass).

Net model, now correct:
- **dev** → built on a commit/push to a PR branch
- **stable** → built when a GitHub Release is published

## Commits
- `1aa4f1f` — first (wrong) approach: reorder `release.yml` to build before publishing. **Reverted** by `27efa5c` (contradicted the "release triggers the build" model).
- `27efa5c` — add the `release: published` trigger + the regression test.
- `f96ab3b` — restore `contents: write` + `continue-on-error` on the commit-comment step.

Happy to squash on merge if you'd like a clean history.

## Verification note
The run on `27efa5c` confirmed the heavy Docker build itself is healthy (image built + pushed to GHCR); only the comment step failed. The `f96ab3b` push touches only `build.yml`, which the push trigger ignores (`paths-ignore`), so it won't auto-run a confirming build — but it directly fixes the one proven failure. I can force a verification build if you want.

https://claude.ai/code/session_0139ZEXDRFPT1ArvgJ1xZEHc