### PR TITLE
🎨 Palette: Improve accessibility of disabled round buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,6 @@
 ## 2026-06-08 - Accessible Tooltips for Disabled States
 **Learning:** `pointer-events-none` on parent wrappers completely blocks pointer events, making it impossible for users to interact with or even see tooltips (like `title` attributes) on disabled elements nested inside.
 **Action:** Remove `pointer-events-none` from parent wrappers and apply `disabled:cursor-not-allowed` and dynamic `title` attributes directly to the interactive elements (buttons/inputs) themselves so screen readers and mouse users get context on why the element is disabled.
+## 2024-06-15 - Disabled States Accessibility
+**Learning:** Applying `pointer-events-none` to a parent container blocks pointer events on all children. This prevents disabled child elements from showing `cursor-not-allowed` and makes `title` tooltips inaccessible on hover, ruining the UX for users trying to understand why an element is disabled. Also, applying opacity to a parent compounds with child opacity, leading to poor contrast.
+**Action:** Remove `pointer-events-none` and `opacity-50` from parent wrappers of disabled groups. Apply `disabled:opacity-50`, `disabled:cursor-not-allowed`, and informative `title` attributes directly to the interactive child elements to preserve tooltip accessibility and clear interaction feedback.

--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -207,7 +207,7 @@
                     </div>
 
                     <div>
-                        <div role="group" aria-labelledby="round-label" tabindex="0" class="flex space-x-3 overflow-x-auto no-scrollbar pb-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded" :class="{'opacity-50 pointer-events-none': scheduleLoading}">
+                        <div role="group" aria-labelledby="round-label" tabindex="0" class="flex space-x-3 overflow-x-auto no-scrollbar pb-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded">
                             <template x-if="scheduleLoading">
                                 <span class="flex items-center text-xs text-gray-500 italic mt-1.5 pt-1">
                                     <i class="fas fa-circle-notch fa-spin mr-1.5" aria-hidden="true"></i>Loading schedule...
@@ -217,8 +217,9 @@
                                 <button @click="selectRound(r.round)"
                                     :disabled="scheduleLoading || loading"
                                     :aria-current="params.round === r.round ? 'true' : 'false'"
+                                    :title="(scheduleLoading || loading) ? 'Loading...' : 'Select Round ' + (r.round || index + 1)"
                                     :class="params.round === r.round ? 'bg-red-600 text-white border-red-500' : 'bg-gray-800 text-gray-400 border-gray-700 hover:border-gray-500 hover:bg-gray-700 hover:text-gray-300'"
-                                    class="flex-shrink-0 text-xs px-3 py-1.5 rounded border transition focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 flex flex-col items-center justify-center min-w-[70px] disabled:cursor-not-allowed">
+                                    class="flex-shrink-0 text-xs px-3 py-1.5 rounded border transition focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 flex flex-col items-center justify-center min-w-[70px] disabled:opacity-50 disabled:cursor-not-allowed">
                                     <span class="font-bold mb-0.5 whitespace-nowrap" x-text="'Round ' + (r.round || index + 1)"></span>
                                     <span class="text-[10px] uppercase tracking-tighter w-full max-w-[90px] truncate text-center" :class="params.round === r.round ? 'opacity-100' : 'opacity-75'" x-text="r.raceName.replace(' Grand Prix', '')"></span>
                                 </button>


### PR DESCRIPTION
💡 **What:** 
- Removed `pointer-events-none` and `opacity-50` from the parent `div` that groups the schedule round buttons.
- Added `disabled:opacity-50` and dynamic `:title` attributes (e.g., "Loading..." or "Select Round N") directly to the `<button>` elements.

🎯 **Why:** 
Previously, setting `pointer-events-none` on the parent container completely blocked hover interactions on the disabled buttons, rendering their `cursor-not-allowed` styles and any potential tooltips useless. Additionally, putting `opacity-50` on the parent compounded with any potential opacity changes on the children, leading to terrible contrast (effectively 25% opacity). By handling disabled states directly on the buttons, the UI remains accessible and correctly conveys loading/disabled contexts.

📸 **Before/After:**
*(Visual changes verified via Playwright screenshot; hover states now function during loading rather than being blocked by the parent)*

♿ **Accessibility:**
Enabled helpful `title` tooltips for keyboard/mouse users to understand *why* the buttons are disabled (e.g., "Loading...") instead of just appearing as dead UI elements.

---
*PR created automatically by Jules for task [4666635306129511004](https://jules.google.com/task/4666635306129511004) started by @2fst4u*