### PR TITLE
Discord >20-driver fix + fully self-learning pace prediction

### DIFF
--- a/f1pred/calibrate.py
+++ b/f1pred/calibrate.py
@@ -1191,27 +1191,16 @@ class CalibrationManager:
                 arr_bt = _h_team_at(arr_bt_grid)
                 arr_mixed = _h_team_at(arr_mixed_grid)
 
-                # Production baseline: base = -form - w_team * team_form,
-                # then pace = w_gbm * gbm + w_base * base.
-                base = form_pace + wb_tm * arr_base_team
-                raw_pace = wb_gbm * arr_gbm_raw + wb_form * base
-
-                p_z = _event_z(raw_pace, event_indices, n_unique)
-
-                # Current-weekend qualifying blend (mirrors models.py): for drivers
-                # with a current-quali result, blend their z-scored pace with the
-                # z-scored qualifying position using current_quali_factor (param 10).
-                # Applied before grid stickiness, exactly as in production.
-                p_z = np.where(
-                    quali_blend_mask,
-                    (1.0 - w_quali) * p_z + w_quali * q_z_precomputed,
-                    p_z,
-                )
-
-                # Grid anchor-delta, the actual production formula in models.py:
-                # final = grid + pace_z * (1 - stickiness) * MAX_DELTA
-                pace_pos = grid_filled + p_z * (1.0 - wb_grid) * 10.0
-                a_z = _event_z(pace_pos, event_indices, n_unique)
+                # Self-learning model: the race pace IS the GBM's learned output
+                # (arr_gbm_raw), trained on real outcomes with grid,
+                # current_quali_pos, circuit proficiency, weather, form, etc. as
+                # features.  Production no longer applies a hand-coded form blend,
+                # qualifying blend, or grid anchor-delta, so the calibration
+                # surrogate must not either — otherwise the ensemble/DNF/noise
+                # weights would be tuned against a model that no longer runs.
+                # (wb_gbm/wb_form/wb_tm/wb_grid/w_quali therefore no longer drive
+                # the race objective; they are anchored to defaults by the L2 reg.)
+                a_z = _event_z(arr_gbm_raw, event_indices, n_unique)
 
                 # Normalise race ensemble weights
                 race_wsum = we_pace + we_elo + we_bt + we_mixed
@@ -1270,9 +1259,9 @@ class CalibrationManager:
                         (arr_q_s_pre + w_q_season * arr_q_s_cur) / np.maximum(q_denom, 1e-9),
                         0.0,
                     )
-                    q_base = -q_form_idx + wb_tm * arr_q_team
-                    raw_q = wb_gbm * arr_q_gbm + wb_form * q_base
-                    q_z = _event_z(raw_q, q_event_indices, n_q_unique)
+                    # Qualifying pace is likewise the GBM's learned output directly
+                    # (no form blend), matching the self-learning production path.
+                    q_z = _event_z(arr_q_gbm, q_event_indices, n_q_unique)
 
                     q_wsum = we_q_pace + we_q_elo + we_q_bt + we_q_mixed
                     if q_wsum < 1e-9:

--- a/f1pred/models.py
+++ b/f1pred/models.py
@@ -397,6 +397,20 @@ def build_hist_training_X(hist: 'pd.DataFrame', X_current: 'pd.DataFrame',
 
         same_evt_q_mask = (qual_seasons == s) & (qual_rounds == r)
         evt_q_indices = np.where(same_evt_q_mask)[0]
+
+        # This weekend's raw qualifying order (current_quali_pos), known before
+        # the race.  Mirrors the inference feature so the GBM can learn how much
+        # the actual one-lap result drives the finishing order.  Prefer the main
+        # qualifying session, falling back to sprint qualifying.
+        cur_quali_pos = np.full(n_drivers, np.nan, dtype=float)
+        if len(evt_q_indices) > 0:
+            for _q_sess in ("qualifying", "sprint_qualifying"):
+                sel = evt_q_indices[qual_sessions[evt_q_indices] == _q_sess]
+                for qi in sel:
+                    c = q_dcodes[qi]
+                    if c >= 0 and np.isnan(cur_quali_pos[c]):
+                        cur_quali_pos[c] = float(qual_pos[qi])
+
         if len(evt_q_indices) > 0:
             q_form_pre, tm_delta_pre, sq_form_pre, valid_sq_pre = _quali_form_stats(
                 prior_q_mask & ~same_evt_q_mask
@@ -461,6 +475,7 @@ def build_hist_training_X(hist: 'pd.DataFrame', X_current: 'pd.DataFrame',
                 "sprint_qualifying_form_index": float(sprint_q_form_index[code]) if valid_sq[code] else float(q_form_index[code]),
                 "teammate_delta": float(tm_delta_index[code]),
                 "grid": float(races_grid_float[idx]),
+                "current_quali_pos": float(cur_quali_pos[code]) if not np.isnan(cur_quali_pos[code]) else np.nan,
                 "is_race": 1 if races_sessions[idx] == "race" else 0,
                 "is_qualifying": 0,
                 "is_sprint": 1 if races_sessions[idx] == "sprint" else 0,
@@ -632,9 +647,13 @@ def train_pace_model(X: 'pd.DataFrame', session_type: str, cfg: Any = None,
     # Features (exclude identifiers, session meta, and the target to prevent leakage).
     # With outcome training the form indices all remain features; with the legacy
     # form target only the target's own column is excluded.
+    # Note: current_quali_pos (this weekend's raw qualifying order) is deliberately
+    # NOT excluded — it is a legitimate pre-race input variable and is now learned
+    # by the model rather than blended in with a hand-coded weight.  It is only
+    # populated for race/sprint feature rows, so it stays NaN (imputed) elsewhere.
     exclude_cols = [
         "driverId", "name", "code", "constructorId", "constructorName", "number",
-        "session_type", "current_quali_pos", "y_pace",
+        "session_type", "y_pace",
     ]
     if target_col is not None:
         exclude_cols.append(target_col)
@@ -752,158 +771,40 @@ def train_pace_model(X: 'pd.DataFrame', session_type: str, cfg: Any = None,
 
         yhat = pipe.predict(X_infer)
 
-    # Build baseline from form indices (for robustness)
-    # Use appropriate form index as the baseline for this session type
-    base = np.zeros(len(X), dtype=float)
-    is_inference_quali = session_type in ("qualifying", "sprint_qualifying")
-    infer_base_col = "qualifying_form_index" if is_inference_quali else "form_index"
+    # The GBM is trained on REAL outcomes (y_pace) with every available input
+    # variable as a feature — form indices, grid, current_quali_pos, circuit
+    # proficiency, weather effect, teammate/grid-finish deltas, team form, etc.
+    # Its output therefore *is* the learned pace: the model decides, from data,
+    # how much each variable matters for this session type.  No hand-coded
+    # blending weights, qualifying overrides, or grid-anchoring constants are
+    # applied — those would impose fixed assumptions the data should determine.
+    pace_hat = np.asarray(yhat, dtype=float)
 
-    if infer_base_col not in X.columns:
-         infer_base_col = "form_index" if infer_base_col == "qualifying_form_index" else "qualifying_form_index"
+    # Robustness guard ONLY (not a weighting choice): if the model could not
+    # learn any signal — degenerate or empty training data — fall back to a
+    # data-derived ordering from the strongest available form signal so the
+    # downstream ranking is still meaningful instead of uniform.
+    if not np.isfinite(np.nanstd(pace_hat)) or np.nanstd(pace_hat) < 1e-6:
+        is_inference_quali = session_type in ("qualifying", "sprint_qualifying")
+        infer_base_col = "qualifying_form_index" if is_inference_quali else "form_index"
+        if infer_base_col not in X.columns:
+            infer_base_col = "form_index" if infer_base_col == "qualifying_form_index" else "qualifying_form_index"
 
-    if infer_base_col in X.columns:
-        base = -X[infer_base_col].astype(float).values
-    
-    # Blending weights from config or defaults
-    w_base_team = 0.3
-    w_grid = 0.8
-    w_gbm = 0.75
-    w_base = 0.25
-    w_quali = 0.5
-    
-    if cfg:
-        try:
-            w_gbm = cfg.modelling.blending.gbm_weight
-            w_base = cfg.modelling.blending.baseline_weight
-            w_base_team = cfg.modelling.blending.baseline_team_factor
-            w_grid = getattr(cfg.modelling.blending, "grid_factor", 0.8)
-            w_quali = getattr(cfg.modelling.blending, "current_quali_factor", 0.5)
-        except AttributeError:
-            pass
+        base = np.zeros(len(X), dtype=float)
+        if infer_base_col in X.columns:
+            # form_index is HIGHER = BETTER, so negate for pace (LOWER = FASTER)
+            base = -X[infer_base_col].astype(float).values
 
-    if "team_form_index" in X.columns:
-        # team_form_index is points-based, HIGHER = BETTER, so negate
-        base = base - w_base_team * X["team_form_index"].astype(float).values
+        # Tie-break deterministically if even the fallback form is flat.
+        if np.nanstd(base) < 1e-9 and "driverId" in X.columns:
+            try:
+                h = pd.util.hash_pandas_object(X["driverId"], index=False).astype(np.uint64) % 997
+                base = base + (h.astype(float) / 1e6)
+            except Exception:
+                pass
 
-    # Add small jitter if baseline is flat (for tie-breaking)
-    if np.nanstd(base) < 1e-9 and "driverId" in X.columns:
-        try:
-            h = pd.util.hash_pandas_object(X["driverId"], index=False).astype(np.uint64) % 997
-            base = base + (h.astype(float) / 1e6)
-        except Exception:
-            pass
-
-    # Blend model predictions with baseline
-    yhat_std = float(np.nanstd(yhat))
-    base_std = float(np.nanstd(base))
-
-    if yhat_std < 1e-6 and base_std > 1e-6:
-        # Model failed to learn, use baseline only
+        logger.info("[models] GBM produced no signal; using data-derived form fallback (%s)", infer_base_col)
         pace_hat = base
-    elif base_std < 1e-6 and yhat_std > 1e-6:
-        # Baseline is flat (e.g., all same form), use model only
-        pace_hat = yhat
-    elif yhat_std > 1e-6 and base_std > 1e-6:
-        # Both have signal - weight heavily towards trained model
-        pace_hat = w_gbm * yhat + w_base * base
-    else:
-        # Both flat - use baseline with small noise for tie-breaking
-        # ⚡ Bolt: standard_normal is slightly faster than normal(0, scale) due to less C overhead
-        pace_hat = base + np.random.RandomState(42).standard_normal(len(base)) * 0.01
-
-    # Stage 1.5: Blend current weekend qualifying position if available
-    # This is a direct, high-weight signal from THIS weekend's qualifying
-    # Applied before grid stickiness so both qualifying pace and grid influence the result
-    if session_type in ("race", "sprint") and "current_quali_pos" in X.columns:
-        quali_vals = X["current_quali_pos"].astype(float).values
-        has_quali = ~np.isnan(quali_vals)
-        if has_quali.any():
-            # Normalize pace_hat to z-score for fair blending
-            p_mu = float(np.nanmean(pace_hat))
-            p_sd = float(np.nanstd(pace_hat))
-            if p_sd > 1e-6:
-                pace_z = (pace_hat - p_mu) / p_sd
-            else:
-                pace_z = pace_hat - p_mu
-
-            # Normalize qualifying positions to z-score (lower position = faster = lower z)
-            q_mu = float(np.nanmean(quali_vals[has_quali]))
-            q_sd = float(np.nanstd(quali_vals[has_quali]))
-            if q_sd > 1e-6:
-                quali_z = (quali_vals - q_mu) / q_sd
-            else:
-                quali_z = quali_vals - q_mu
-
-            # Blend: w_quali controls how much current qualifying overrides historical form
-            blended_z = np.where(
-                has_quali,
-                (1.0 - w_quali) * pace_z + w_quali * quali_z,
-                pace_z  # Keep original for drivers without qualifying data
-            )
-
-            # Rescale back to original pace scale
-            if p_sd > 1e-6:
-                pace_hat = blended_z * p_sd + p_mu
-            else:
-                pace_hat = blended_z + p_mu
-
-            logger.info(
-                "[models] Blended current_quali_pos (factor=%.2f) for %d/%d drivers",
-                w_quali, has_quali.sum(), len(X)
-            )
-
-    # Second Stage: Incorporate grid "stickiness" for race sessions
-    # This ensures starting position acts as a strong anchor for the prediction.
-    if session_type in ("race", "sprint") and "grid" in X.columns:
-        # Dynamic stickiness based on circuit passability and driver skill.
-        # The base w_grid is calibrated; circuit and driver adjustments scale
-        # proportionally to the flexibility budget (1 - w_grid) so they
-        # automatically adapt when the calibrated grid factor changes.
-        dynamic_w_grid = w_grid
-        flexibility = max(1.0 - w_grid, 0.05)  # how much non-grid signal is allowed
-
-        # 1. Circuit overtake difficulty
-        if "circuit_overtake_difficulty" in X.columns:
-            avg_circuit_diff = float(np.nanmean(X["circuit_overtake_difficulty"]))
-            if not np.isnan(avg_circuit_diff):
-                # Negative = hard to pass -> increase stickiness
-                circuit_modifier = -avg_circuit_diff * flexibility * 0.15
-                dynamic_w_grid = dynamic_w_grid + circuit_modifier
-
-        # 2. Driver overtake propensity
-        if "grid_finish_delta" in X.columns:
-            # Positive = driver gains positions -> decrease stickiness
-            driver_gfd = X["grid_finish_delta"].astype(float).values
-            driver_modifier = -np.nan_to_num(driver_gfd) * flexibility * 0.08
-            dynamic_w_grid = dynamic_w_grid + driver_modifier
-
-        dynamic_w_grid = np.clip(dynamic_w_grid, 0.4, 0.95)
-
-        # 1. Grid is the absolute anchor
-        # Use actual grid if available, otherwise fallback to index/average
-        grid_fallback = float(len(X)) if len(X) > 0 else 20.0
-        grid_vals = X["grid"].astype(float).fillna(grid_fallback).values
-        
-        # 2. Normalize pace_hat to determine pace relative advantage (z-score)
-        mu = float(np.nanmean(pace_hat))
-        sd = float(np.nanstd(pace_hat))
-        if sd > 1e-6:
-            pace_z = (pace_hat - mu) / sd
-        else:
-            pace_z = pace_hat - mu
-            
-        # 3. Apply pace advantage as a Delta to the anchor
-        # Max reasonable delta bounded to 10 positions (a 2 sigma pace advantage = ~5 grid slots)
-        MAX_DELTA = 10.0
-        pace_multiplier = 1.0 - dynamic_w_grid
-        pace_delta = pace_z * pace_multiplier * MAX_DELTA
-        
-        # 4. Final simulated baseline is Grid + Expected Delta
-        pace_hat = grid_vals + pace_delta
-        
-        logger.info(
-            "[models] Applied dynamic Anchor-Delta grid stickiness modified by circuit and driver"
-        )
 
     # Compute SHAP values for explainability
     shap_per_driver = None

--- a/f1pred/prediction_manager.py
+++ b/f1pred/prediction_manager.py
@@ -807,16 +807,46 @@ class PredictionManager:
                         lines.append(f"{prefix} `P{pos_str}` **{code}**{move}")
                     return "\n".join(lines) or "*No data*"
 
-                embed["fields"].append({
-                    "name": "Top 10",
-                    "value": format_grid_lines(sorted_preds[:10]),
-                    "inline": True
-                })
-                embed["fields"].append({
-                    "name": "Bottom 10",
-                    "value": format_grid_lines(sorted_preds[10:20]),
-                    "inline": True
-                })
+                # Split the full field into two balanced columns so every driver
+                # is shown, even when the grid has more than 20 entries (reserve
+                # drivers, expanded rosters, etc.). Discord caps a field value at
+                # 1024 chars, so chunk further if a column would overflow.
+                half = (len(sorted_preds) + 1) // 2
+                columns = [sorted_preds[:half], sorted_preds[half:]] if sorted_preds else []
+
+                def chunk_for_discord(preds):
+                    """Yield (label_suffix, lines) chunks under Discord's 1024 char field limit."""
+                    chunks: list[list[dict]] = []
+                    current: list[dict] = []
+                    current_len = 0
+                    for p in preds:
+                        # Approximate rendered length; format_grid_lines joins with newlines.
+                        line_len = len(format_grid_lines([p])) + 1
+                        if current and current_len + line_len > 1024:
+                            chunks.append(current)
+                            current = []
+                            current_len = 0
+                        current.append(p)
+                        current_len += line_len
+                    if current:
+                        chunks.append(current)
+                    return chunks
+
+                for col_idx, column in enumerate(columns):
+                    if not column:
+                        continue
+                    for chunk in chunk_for_discord(column):
+                        first_pos = chunk[0].get("predicted_position")
+                        last_pos = chunk[-1].get("predicted_position")
+                        if first_pos is not None and last_pos is not None:
+                            name = f"P{first_pos}–P{last_pos}"
+                        else:
+                            name = "Top half" if col_idx == 0 else "Bottom half"
+                        embed["fields"].append({
+                            "name": name,
+                            "value": format_grid_lines(chunk),
+                            "inline": True
+                        })
 
                 embeds.append(embed)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -183,8 +183,9 @@ def test_build_hist_training_X_boost_factors_are_wired_through(boost_kwarg, affe
         f"{boost_kwarg} did not change {affected_col} — boost not wired to its index"
     )
     for col in boosted.select_dtypes("number").columns:
-        if col == "grid":
-            # Qualifying samples intentionally have no grid (imputed downstream)
+        if col in ("grid", "current_quali_pos"):
+            # Qualifying samples intentionally have no grid / current_quali_pos
+            # (both are race-only pre-race signals, imputed downstream).
             continue
         assert np.all(np.isfinite(boosted[col].values))
     # Outcome targets must be present and labelled for every sample.
@@ -260,6 +261,72 @@ def test_build_hist_training_X_none_history():
     X_current = pd.DataFrame({"driverId": ["driver_1"], "form_index": [0.0]})
     assert build_hist_training_X(None, X_current, datetime.now(timezone.utc)) is None
     assert build_hist_training_X(pd.DataFrame(), X_current, datetime.now(timezone.utc)) is None
+
+
+def test_current_quali_pos_is_a_learned_feature():
+    """current_quali_pos must be plumbed into the training matrix (race rows only)
+    and consumed by the GBM as a feature, rather than blended via a hard-coded weight.
+
+    This is part of making the model fully self-learning: the weekend's raw
+    qualifying order is an input variable whose importance the model learns.
+    """
+    from f1pred.models import build_hist_training_X, train_pace_model
+
+    hist, X_current, ref = _two_season_history()
+    hist_X = build_hist_training_X(hist, X_current, ref)
+    assert hist_X is not None
+
+    # Column must exist and be populated for race/sprint samples (from that
+    # weekend's qualifying), while qualifying samples stay NaN.
+    assert "current_quali_pos" in hist_X.columns
+    race_rows = hist_X[hist_X["is_race"] == 1]
+    quali_rows = hist_X[hist_X["is_qualifying"] == 1]
+    assert race_rows["current_quali_pos"].notna().any(), \
+        "current_quali_pos should be populated for race samples"
+    assert quali_rows["current_quali_pos"].isna().all(), \
+        "current_quali_pos must be absent (NaN) for qualifying samples"
+
+    # And it must be picked up as a model feature (not excluded).
+    X_infer = X_current.copy()
+    X_infer["current_quali_pos"] = list(range(1, len(X_infer) + 1))
+    _, pace_hat, features, _ = train_pace_model(
+        X_infer, session_type="race", hist_X=hist_X,
+    )
+    assert "current_quali_pos" in features
+    assert np.all(np.isfinite(pace_hat))
+
+
+def test_grid_is_not_a_hardcoded_anchor():
+    """Grid must influence pace only through what the model *learns*, not via a
+    hard-coded anchor.  When grid carries no signal in training, varying it at
+    inference must NOT reorder the predictions — the old grid-stickiness code
+    (pace = grid + delta) would have forced the order to follow grid regardless.
+    """
+    from f1pred.models import build_hist_training_X, train_pace_model
+
+    hist, X_current, ref = _two_season_history()
+    hist_X = build_hist_training_X(hist, X_current, ref)
+    assert hist_X is not None
+
+    # Strip grid of any learnable signal in the training matrix.
+    hist_X = hist_X.copy()
+    hist_X["grid"] = 1.0
+
+    X_infer = X_current.copy()
+    X_infer["form_index"] = np.linspace(5, -5, len(X_infer))
+
+    # Two inference frames identical except for grid (ascending vs reversed).
+    X_a = X_infer.copy()
+    X_a["grid"] = list(range(1, len(X_a) + 1))
+    X_b = X_infer.copy()
+    X_b["grid"] = list(range(len(X_b), 0, -1))
+
+    _, pace_a, _, _ = train_pace_model(X_a, session_type="race", hist_X=hist_X)
+    _, pace_b, _, _ = train_pace_model(X_b, session_type="race", hist_X=hist_X)
+
+    # Grid had no training signal, so it cannot move the predictions.
+    assert np.allclose(pace_a, pace_b), \
+        "grid changed the prediction despite carrying no learned signal — anchor still present"
 
 
 def test_train_pace_model_with_hist_X(sample_features):

--- a/tests/test_prediction_manager.py
+++ b/tests/test_prediction_manager.py
@@ -713,20 +713,20 @@ class TestPredictionManagerDiscord:
 
                     # Check race embed
                     r_embed = next(e for e in payload["embeds"] if "🏁 Test GP 2024 R1 (Race)" in e["title"])
-                    top10_field = next(f for f in r_embed["fields"] if f["name"] == "Top 10")
-                    assert "HAM" in top10_field["value"]
-                    assert "VER" in top10_field["value"]
-                    assert "▲" in top10_field["value"] # HAM moved up (from P2 to P1)
-                    assert "▼" in top10_field["value"] # VER moved down (from P1 to P2)
+                    # Grid fields are the position columns (names like "P1–P1").
+                    grid_fields = [f for f in r_embed["fields"] if "`P" in f["value"]]
+                    grid_text = "\n".join(f["value"] for f in grid_fields)
+                    assert "HAM" in grid_text
+                    assert "VER" in grid_text
+                    assert "▲" in grid_text  # HAM moved up (from P2 to P1)
+                    assert "▼" in grid_text  # VER moved down (from P1 to P2)
 
-                    # Check order in Top 10 field
-                    lines = top10_field["value"].split("\n")
-                    # Find lines with P01 and P02
+                    # Check order across the grid: P01 (HAM) before P02 (VER)
+                    lines = grid_text.split("\n")
                     p1_line = next(l for l in lines if "`P01`" in l)
                     p2_line = next(l for l in lines if "`P02`" in l)
                     assert "HAM" in p1_line
                     assert "VER" in p2_line
-                    # P1 should come before P2 in the lines
                     assert lines.index(p1_line) < lines.index(p2_line)
 
                     # Check "Movers & Shakers" field
@@ -734,6 +734,71 @@ class TestPredictionManagerDiscord:
                     assert "HAM" in movers_field["value"]
                     assert "+1" in movers_field["value"]
 
-                    # Check two-column grid layout (Bottom 10 exists)
-                    bottom10_field = next(f for f in r_embed["fields"] if f["name"] == "Bottom 10")
-                    assert bottom10_field["inline"] is True
+                    # Check two-column grid layout (both columns inline)
+                    assert len(grid_fields) >= 2
+                    assert all(f["inline"] is True for f in grid_fields)
+
+    def test_discord_webhook_handles_more_than_20_drivers(self):
+        """Regression: every driver must appear in the grid, even beyond P20."""
+        import pandas as pd
+        from unittest.mock import MagicMock, patch
+        from f1pred.prediction_manager import PredictionManager, _fingerprint_predictions
+
+        cfg = MagicMock()
+        cfg.modelling.targets.session_types = ["race"]
+        cfg.paths.cache_dir = "cache"
+
+        manager = PredictionManager(cfg, poll_interval=60)
+        manager._latest_results = {"season": 2024, "rounds": {}}
+
+        # 24-driver grid (more than the classic 20).
+        n_drivers = 24
+        new_rows = []
+        for i in range(1, n_drivers + 1):
+            new_rows.append({
+                "driverId": f"d{i}",
+                "predicted_position": i,
+                "code": f"D{i:02}",
+                "name": f"Driver {i}",
+                "constructorName": "Team",
+                "p_win": 0.0,
+                "p_top3": 0.0,
+                "mean_pos": float(i),
+            })
+        df_new = pd.DataFrame(new_rows)
+
+        # Seed previous state so a diff fires.
+        old_preds = [dict(r, predicted_position=n_drivers + 1 - r["predicted_position"]) for r in new_rows]
+        old_fp = _fingerprint_predictions(old_preds)
+        manager._previous_fingerprints = {"1_race": old_fp}
+        manager._previous_predictions = {"1_race": old_preds}
+        manager._previous_weather = {"1_race": {"temp_mean": 20}}
+
+        fake_results = {
+            "season": 2024,
+            "round": 1,
+            "sessions": {
+                "race": {"ranked": df_new, "meta": {"weather": {"temp_mean": 25}}},
+            },
+        }
+
+        with patch('f1pred.predict.run_predictions_for_event', return_value=fake_results):
+            with patch.object(manager, '_get_setting', return_value="https://discord.com/api/webhooks/test"):
+                with patch('httpx.post') as mock_post:
+                    jc = MagicMock()
+                    jc.get_race_results.return_value = []
+                    jc.get_qualifying_results.return_value = []
+                    manager._predict_round(jc, 2024, 1, {"raceName": "Test GP", "round": 1})
+
+                    assert mock_post.called
+                    payload = mock_post.call_args.kwargs['json']
+                    r_embed = payload["embeds"][0]
+                    grid_text = "\n".join(
+                        f["value"] for f in r_embed["fields"] if "`P" in f["value"]
+                    )
+                    # All 24 drivers must be present, including those past P20.
+                    for i in range(1, n_drivers + 1):
+                        assert f"D{i:02}" in grid_text, f"Driver D{i:02} missing from Discord grid"
+                    # Discord field values must stay under the 1024 char limit.
+                    for f in r_embed["fields"]:
+                        assert len(f["value"]) <= 1024


### PR DESCRIPTION
## 1. Discord notification dropped drivers beyond P20

The grid display hardcoded `sorted_preds[:10]` (Top 10) and `sorted_preds[10:20]`
(Bottom 10), so any driver past position 20 — reserve drivers, expanded rosters,
or any field larger than 20 — was silently dropped from the notification.

**Fix:** split the **full** ranked field into two balanced columns, chunked
further so each Discord field value stays under the 1024-char limit. Field names
now reflect the actual position range shown (e.g. `P1–P12`).

## 2. Predictions looked near-identical every race

Investigation of the whole pipeline showed this was **not** a missing-variable
bug — every per-driver feature (form, qualifying form, circuit proficiency,
weather effect, teammate/grid-finish deltas, team form, grid) is present in both
training and inference. The similarity was **structural**: race pace was
overwritten by a hand-coded grid anchor (`pace = grid + delta`) plus fixed-weight
blends with a form baseline and current qualifying position. Those magic weights
(`gbm_weight`, `baseline_weight`, `grid_factor`, `current_quali_factor`) swamped
the per-race variables.

Per the requested direction (**fully self-learning, no hard-coded weights, open
to all input variables**):

- The GBM — trained on real outcomes with every input variable as a feature —
  now produces the pace **directly**. The model learns from data how much each
  variable matters per session type. Only a data-derived form fallback remains,
  purely as a degenerate-data guard.
- `grid` and `current_quali_pos` are now ordinary **learned features**.
  `current_quali_pos` is plumbed into the historical training matrix for
  race/sprint rows so the model can actually learn the weekend's one-lap signal.
- The calibration objective surrogate is aligned to the same learned pace, so the
  ensemble/DNF/noise weights are tuned against the model that actually runs
  rather than the removed grid-anchored path.

### Regression tests added
- `current_quali_pos` is present (race rows) / absent (qualifying rows) in the
  training matrix and is consumed as a model feature.
- `grid` no longer acts as a hard anchor: when it carries no learned signal,
  varying it at inference does not reorder predictions.
- Discord grid shows all 24 drivers for a >20-driver field, every field ≤1024 chars.

## Testing
All affected suites pass locally (168 passed across models / features / ensemble /
prediction-manager / calibration unit tests). Remaining failures in this sandbox
are environmental only (missing pinned `bcrypt==3.2.0`, and a pandas-version
StringArray issue in `_teammate_matrices`) and are unrelated to these changes.

> Note: the self-learning change alters the prediction outputs users see. It is
> backed by unit tests but could not be backtested in this environment (no
> network access to Jolpica / FastF1 / Open-Meteo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)