### PR TITLE
🎨 Palette: Fix disabled state contrast and tooltips in Integrations settings

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,6 @@
 ## 2024-06-15 - Disabled States Accessibility
 **Learning:** Applying `pointer-events-none` to a parent container blocks pointer events on all children. This prevents disabled child elements from showing `cursor-not-allowed` and makes `title` tooltips inaccessible on hover, ruining the UX for users trying to understand why an element is disabled. Also, applying opacity to a parent compounds with child opacity, leading to poor contrast.
 **Action:** Remove `pointer-events-none` and `opacity-50` from parent wrappers of disabled groups. Apply `disabled:opacity-50`, `disabled:cursor-not-allowed`, and informative `title` attributes directly to the interactive child elements to preserve tooltip accessibility and clear interaction feedback.
+## 2024-05-18 - Disabled Input Tooltips and Opacity
+**Learning:** When a parent wrapper has `opacity-50`, it compounds with the opacity of disabled child elements (like inputs and labels), resulting in poor contrast and unreadable tooltips. It also makes the container look inconsistent with sibling containers.
+**Action:** Remove `opacity-50` from parent wrappers of disabled groups. Instead, apply `disabled:opacity-50` directly to interactive elements (like inputs) and standard `opacity-50` to non-interactive associated elements (like labels) to preserve contrast and accessibility.

--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -727,16 +727,16 @@
 
                             <div>
                                 <h3 class="text-sm font-medium text-gray-200 mb-3">Integrations (Coming Soon)</h3>
-                                <div class="bg-gray-900/50 p-5 rounded border border-gray-700 space-y-5 opacity-50">
+                                <div class="bg-gray-900/50 p-5 rounded border border-gray-700 space-y-5">
                                     <div>
-                                        <label for="llm-server-url" class="block text-sm font-medium text-gray-400 mb-1">LLM Server URL</label>
+                                        <label for="llm-server-url" class="block text-sm font-medium text-gray-400 mb-1 opacity-50">LLM Server URL</label>
                                         <input id="llm-server-url" type="text" x-model="settings.llm_server_url" disabled title="This feature is coming soon"
-                                            class="block w-full bg-gray-800 border border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm text-white disabled:cursor-not-allowed">
+                                            class="block w-full bg-gray-800 border border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm text-white disabled:opacity-50 disabled:cursor-not-allowed">
                                     </div>
                                     <div>
-                                        <label for="llm-api-key" class="block text-sm font-medium text-gray-400 mb-1">LLM API Key</label>
+                                        <label for="llm-api-key" class="block text-sm font-medium text-gray-400 mb-1 opacity-50">LLM API Key</label>
                                         <input id="llm-api-key" type="password" x-model="settings.llm_api_key" disabled title="This feature is coming soon"
-                                            class="block w-full bg-gray-800 border border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm text-white disabled:cursor-not-allowed">
+                                            class="block w-full bg-gray-800 border border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm text-white disabled:opacity-50 disabled:cursor-not-allowed">
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
💡 **What**: Removed `opacity-50` from the parent wrapper of the "Integrations (Coming Soon)" settings section and applied it individually to the child `<label>` elements, while using `disabled:opacity-50` on the disabled `<input>` fields.
🎯 **Why**: Parent container opacity compounded the visual fade of the disabled inputs, leading to poor color contrast and making the section visually inconsistent with neighboring settings cards.
📸 **Before/After**: The background and border of the integrations card now match the rest of the application, while the disabled controls inside it remain properly faded.
♿ **Accessibility**: Moving the opacity off the parent prevents the `title="This feature is coming soon"` tooltips on the input elements from being difficult to read due to compounded transparency rules.

---
*PR created automatically by Jules for task [12905109435934478208](https://jules.google.com/task/12905109435934478208) started by @2fst4u*