### PR TITLE
🎨 Palette: Add password visibility toggles to auth forms

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -14,3 +14,7 @@
 ## 2024-05-18 - Disabled Input Tooltips and Opacity
 **Learning:** When a parent wrapper has `opacity-50`, it compounds with the opacity of disabled child elements (like inputs and labels), resulting in poor contrast and unreadable tooltips. It also makes the container look inconsistent with sibling containers.
 **Action:** Remove `opacity-50` from parent wrappers of disabled groups. Instead, apply `disabled:opacity-50` directly to interactive elements (like inputs) and standard `opacity-50` to non-interactive associated elements (like labels) to preserve contrast and accessibility.
+
+## 2024-06-29 - Password Visibility Toggles
+**Learning:** Password fields without visibility toggles are an accessibility hurdle, especially on mobile devices. Adding a toggle reduces user anxiety and entry errors. When implementing a toggle using Alpine.js and absolute positioning within a relative container, it's critical to add sufficient padding (e.g., `pr-10`) to the input to prevent text from overlapping the toggle icon. Furthermore, the toggle button itself must be fully accessible with `aria-label`, `title`, and `focus-visible` styles.
+**Action:** When adding password fields, always consider implementing a visibility toggle. Ensure proper input padding to accommodate the absolute positioned icon, and verify the toggle button is accessible.

--- a/f1pred/templates/index.html
+++ b/f1pred/templates/index.html
@@ -658,8 +658,16 @@
                             </div>
                             <div>
                                 <label for="login-password" class="block text-sm font-medium text-gray-300">Password <span class="text-red-500">*</span></label>
-                                <input id="login-password" type="password" x-model="authPassword" required
-                                    class="mt-1 block w-full bg-gray-900 border border-gray-700 rounded-md shadow-sm py-2 px-3 text-sm focus:outline-none focus:ring-1 focus:ring-red-500 focus:border-red-500 text-white">
+                                <div class="relative mt-1">
+                                    <input id="login-password" :type="showAuthPassword ? 'text' : 'password'" x-model="authPassword" required
+                                        class="block w-full bg-gray-900 border border-gray-700 rounded-md shadow-sm py-2 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-red-500 focus:border-red-500 text-white">
+                                    <button type="button" @click="showAuthPassword = !showAuthPassword"
+                                        :aria-label="showAuthPassword ? 'Hide password' : 'Show password'"
+                                        :title="showAuthPassword ? 'Hide password' : 'Show password'"
+                                        class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded-md">
+                                        <i class="fas" :class="showAuthPassword ? 'fa-eye-slash' : 'fa-eye'" aria-hidden="true"></i>
+                                    </button>
+                                </div>
                             </div>
                             <button type="submit" :disabled="authLoading" :title="authLoading ? 'Logging in...' : 'Login'" class="w-full bg-red-600 hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed text-white py-2 px-4 rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white flex justify-center items-center">
                                 <span x-show="!authLoading">Login</span>
@@ -686,13 +694,29 @@
                                     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                                         <div>
                                             <label for="current-password" class="block text-xs font-medium text-gray-400 mb-1">Current Password <span class="text-red-500">*</span></label>
-                                            <input id="current-password" type="password" x-model="passChange.current" required
-                                                class="block w-full bg-gray-800 border border-gray-600 rounded-md shadow-sm py-1.5 px-3 text-xs focus:outline-none focus:ring-1 focus:ring-red-500 focus:border-red-500 text-white">
+                                            <div class="relative">
+                                                <input id="current-password" :type="showCurrentPassword ? 'text' : 'password'" x-model="passChange.current" required
+                                                    class="block w-full bg-gray-800 border border-gray-600 rounded-md shadow-sm py-1.5 pl-3 pr-10 text-xs focus:outline-none focus:ring-1 focus:ring-red-500 focus:border-red-500 text-white">
+                                                <button type="button" @click="showCurrentPassword = !showCurrentPassword"
+                                                    :aria-label="showCurrentPassword ? 'Hide current password' : 'Show current password'"
+                                                    :title="showCurrentPassword ? 'Hide current password' : 'Show current password'"
+                                                    class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded-md">
+                                                    <i class="fas" :class="showCurrentPassword ? 'fa-eye-slash' : 'fa-eye'" aria-hidden="true"></i>
+                                                </button>
+                                            </div>
                                         </div>
                                         <div>
                                             <label for="new-password" class="block text-xs font-medium text-gray-400 mb-1">New Password <span class="text-red-500">*</span></label>
-                                            <input id="new-password" type="password" x-model="passChange.new" required
-                                                class="block w-full bg-gray-800 border border-gray-600 rounded-md shadow-sm py-1.5 px-3 text-xs focus:outline-none focus:ring-1 focus:ring-red-500 focus:border-red-500 text-white">
+                                            <div class="relative">
+                                                <input id="new-password" :type="showNewPassword ? 'text' : 'password'" x-model="passChange.new" required
+                                                    class="block w-full bg-gray-800 border border-gray-600 rounded-md shadow-sm py-1.5 pl-3 pr-10 text-xs focus:outline-none focus:ring-1 focus:ring-red-500 focus:border-red-500 text-white">
+                                                <button type="button" @click="showNewPassword = !showNewPassword"
+                                                    :aria-label="showNewPassword ? 'Hide new password' : 'Show new password'"
+                                                    :title="showNewPassword ? 'Hide new password' : 'Show new password'"
+                                                    class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded-md">
+                                                    <i class="fas" :class="showNewPassword ? 'fa-eye-slash' : 'fa-eye'" aria-hidden="true"></i>
+                                                </button>
+                                            </div>
                                         </div>
                                     </div>
                                     <button type="submit" :disabled="passChangeLoading" :title="passChangeLoading ? 'Updating password...' : 'Update Password'"
@@ -791,6 +815,7 @@
                 isLoggedIn: false,
                 authUsername: '',
                 authPassword: '',
+                showAuthPassword: false,
                 authError: '',
                 authLoading: false,
                 settings: {
@@ -804,6 +829,8 @@
                     current: '',
                     new: ''
                 },
+                showCurrentPassword: false,
+                showNewPassword: false,
                 passChangeLoading: false,
                 passwordChangeError: '',
                 passwordChangeSuccess: false,


### PR DESCRIPTION
💡 **What**: Added password visibility toggles (eye icons) to all password input fields (Login, Current Password, and New Password) in the application settings panel.

🎯 **Why**: Password fields without visibility toggles are an accessibility and usability hurdle, particularly on mobile devices or for users with complex passwords. Allowing users to view their typed password reduces anxiety, prevents form submission errors, and creates a more forgiving user experience.

📸 **Before/After**: (See attached Playwright screenshots/video demonstrating the state toggle).
*   Password fields are now wrapped in relative containers.
*   An absolute positioned eye/eye-slash icon allows toggling visibility.
*   Adequate padding prevents text from hiding under the icon.

♿ **Accessibility**: 
*   The toggle buttons are fully keyboard accessible and include clear `focus-visible:ring` focus states.
*   They use dynamic `aria-label` and `title` attributes that update based on the state ("Show password" vs "Hide password") so screen reader users understand the button's action and current state.
*   The eye icons have `aria-hidden="true"` to prevent redundant reading by assistive technologies.

---
*PR created automatically by Jules for task [10289627466932122982](https://jules.google.com/task/10289627466932122982) started by @2fst4u*